### PR TITLE
fix(cli): ensure binary has execute permissions before spawn

### DIFF
--- a/packages/cli/bin/leanspec-rust.js
+++ b/packages/cli/bin/leanspec-rust.js
@@ -16,7 +16,7 @@ import { spawn } from 'child_process';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { accessSync, openSync, readSync, closeSync } from 'fs';
+import { accessSync, chmodSync, openSync, readSync, closeSync, statSync } from 'fs';
 
 const require = createRequire(import.meta.url);
 const __filename = fileURLToPath(import.meta.url);
@@ -171,6 +171,19 @@ function getBinaryPath() {
 
 // Execute binary
 const binaryPath = getBinaryPath();
+
+// Ensure the binary is executable (npm may unpack files without execute bits)
+const EXEC_BITS = 0o111; // owner + group + other execute
+try {
+  const mode = statSync(binaryPath).mode;
+  if (!(mode & EXEC_BITS)) {
+    chmodSync(binaryPath, mode | EXEC_BITS);
+    debug('Added execute permission to binary:', binaryPath);
+  }
+} catch (e) {
+  debug('Could not ensure execute permission:', e.message);
+}
+
 const args = process.argv.slice(2);
 
 debug('Spawning binary:', binaryPath);


### PR DESCRIPTION
## Summary

- npm and bun may unpack optional dependency binaries without execute bits set, causing `EACCES` on spawn
- Before spawning, check the binary's mode and `chmod +x` if the execute bits are missing
- Adds `statSync` + `chmodSync` from `fs` with a named constant `EXEC_BITS = 0o111` for clarity

## Reproduction

Install `lean-spec` via bun and run any command — the binary lands without execute permissions:
```
Failed to start lean-spec: spawn .../lean-spec EACCES
```

Fixes #171

## Test plan
- [ ] Install package fresh via bun (`bunx lean-spec --version`) and confirm it runs without `EACCES`
- [ ] Verify manually stripping execute bits and re-running auto-fixes them
- [ ] Confirm no regression on Linux/Windows (chmod is a no-op on Windows, but the `try/catch` guards it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)