### PR TITLE
issue-spec: sync abstract skill from onsager-skills

### DIFF
--- a/.agents/skills/issue-spec/.upstream-source
+++ b/.agents/skills/issue-spec/.upstream-source
@@ -1,0 +1,1 @@
+onsager-ai/onsager-skills

--- a/.agents/skills/issue-spec/SKILL.md
+++ b/.agents/skills/issue-spec/SKILL.md
@@ -1,54 +1,59 @@
 ---
 name: issue-spec
-description: Create lean-spec style GitHub issues as specs for human-AI aligned implementation on the lean-spec repo itself. Use when asked to "create a spec", "write a spec issue", "spec this feature", "spec this", or when planning work that needs a specification before implementation. Follows the lean-spec SDD methodology — small focused specs (<2000 tokens), intent over implementation, context economy. Creates GitHub issues on `codervisor/lean-spec` with Overview, Design, Plan, Test, Alignment, and Notes sections. Paired with `lean-spec-dev-process` (the SDD loop), `lean-spec-pre-push` (pre-push checks), and `lean-spec-pr-lifecycle` (post-push).
+description: Create lean-spec style GitHub issues as specs for human-AI aligned implementation on the current repo. Use when asked to "create a spec", "write a spec issue", "spec this feature", "spec this", or when planning work that needs a specification before implementation. Follows the lean-spec SDD methodology — small focused specs (<2000 tokens), intent over implementation, context economy. Creates GitHub issues with Overview, Design, Plan, Test, Alignment, and Notes sections. Repo-specific area taxonomy, sister-skill names, custom body sections (e.g. Provider impact / Schema impact / Reach), and additional principles are overlaid by the consumer repo's CLAUDE.md and its `*-dev-process` / `*-pre-push` / `*-pr-lifecycle` sister skills — read those first when the repo isn't obvious.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git diff:*), Bash(git log:*), Bash(git show:*), mcp__github__issue_write, mcp__github__issue_read, mcp__github__list_issues, mcp__github__search_issues, mcp__github__sub_issue_write, mcp__github__get_label
 ---
 
 # issue-spec
 
-Create GitHub issues as lean-spec style specifications for human-AI aligned implementation on the lean-spec repo (`codervisor/lean-spec`). GitHub issues are the sole spec medium for new work — the historical `specs/` directory is frozen as a snapshot of pre-migration work and is not the source of truth going forward.
+Create GitHub issues as lean-spec style specifications for human-AI aligned implementation on whatever repo this skill is installed in. GitHub issues are the sole spec medium — no spec files.
 
-This skill is the canonical implementation of lean-spec's **github** provider applied to the lean-spec product itself. We dogfood the same workflow we're shipping. If the discipline is awkward here, that's a signal to fix the product, not to bend the discipline.
+This skill is the **repo-agnostic methodology** half of the contract. Each consumer repo overlays its own delta in two places:
 
-This is lean-spec's analogue of the `issue-spec` skills used on `onsager-ai/onsager` and `onsager-ai/duhem`. The discipline is the same; the area taxonomy and the architectural invariants are different — lean-spec has a **provider-agnostic core** invariant and an **i18n discipline** in place of Onsager's seam rule or Duhem's schema-impact rule.
+- **Repo CLAUDE.md** — names the GitHub slug (`codervisor/lean-spec`, `onsager-ai/onsager`, `onsager-ai/duhem`, …) and any repo-specific spec principles (e.g. Onsager's Reach + seam rule, lean-spec's provider-agnostic core + i18n, Duhem's worked-example + schema-impact).
+- **Sister skills** — `<repo>-dev-process` carries the area-label taxonomy, the spec-vs-`trivial` gate, and the SDD loop wiring; `<repo>-pre-push` carries pre-push gates; `<repo>-pr-lifecycle` carries the post-push workflow (including any `pr-spec-sync` automation or the lack of it).
+
+When in doubt about the target repo, run `git remote -v` and read the repo's `CLAUDE.md` and its `*-dev-process` skill before drafting the spec body.
 
 ## Why GitHub Issues, Not Files
 
-The lean-spec product itself is moving from file-based specs (`specs/NNN-slug/README.md` with YAML frontmatter) to GitHub issues as the canonical backend for new work. The mapping:
+lean-spec uses Markdown files with YAML frontmatter for metadata. We replace that entirely with GitHub issues because:
 
 - **Status** → Issue state (open/closed) + status labels (`draft`, `planned`, `in-progress`)
 - **Priority** → Labels (`priority:critical`, `priority:high`, `priority:medium`, `priority:low`)
-- **Tags** → Labels (`area:*`, `feat`, `fix`, `refactor`, `perf`)
+- **Tags** → Labels (`area:<subsystem>`, `feat`, `fix`, `refactor`, `perf`)
 - **Dependencies** → Issue references (`depends on #42`) and sub-issues
 - **Parent/Child** → Sub-issues via `mcp__github__sub_issue_write`
 - **Transitions** → Issue timeline (automatic, auditable)
 - **Collaboration** → Comments, reactions, assignments, mentions
 
-GitHub gives us versioned metadata, collaboration, and relationship tracking for free. The file-based provider remains supported by the product for users who want it; for lean-spec's own development we use issues.
+GitHub gives us versioned metadata, collaboration, and relationship tracking for free. No CLI needed, no frontmatter to manage, no sync problems.
 
 ## Philosophy
 
-Three principles from lean-spec:
+Three principles from lean-spec, universal across consumer repos:
 
 1. **Context Economy** — Keep issue body under ~2000 tokens. Larger features split into parent + child issues. Small specs produce better AI output and better human review.
 2. **Intent Over Implementation** — Document the *why* and *what*, not the *how*. Implementation details belong in PRs, not spec issues. The spec captures human intent that isn't in the code.
 3. **Living Documents** — Specs evolve via issue comments and edits. Status labels track lifecycle. The issue thread becomes the decision record.
 
-Plus two lean-spec-specific principles:
+Each consumer repo may add 1–2 repo-specific principles on top — read the repo's `CLAUDE.md` and its `*-dev-process` sister skill before drafting. Examples of overlay principles you'll find in the wild:
 
-4. **Provider-agnostic core.** Lean-spec's architecture promises that the CLI, MCP, and UI behave identically across backends (markdown / github / future ADO / Jira). Any spec that touches the provider abstraction — types in `packages/ui/src/types/specs.ts`, provider implementations under `rust/leanspec-core/src/providers/`, or anything the UI/CLI reads through that interface — must declare the impact in `## Provider impact`. A change that leaks backend specifics into core is a regression of the central product promise.
+- **Reach ships with the primitive** (Onsager) — new user-facing primitives must scope in nav entry, first-run flow, empty-state CTAs, and auth gating; deferring discoverability is the bad call.
+- **Provider-agnostic core + i18n** (lean-spec) — changes to the provider abstraction declare `## Provider impact`; user-visible strings land in both `en` and `zh-CN`.
+- **Worked example + schema impact** (Duhem) — product-surface specs ship with a minimal Verification Definition that exercises the surface; schema-touching changes declare `## Schema impact`.
 
-5. **i18n is mandatory.** Every user-facing string lands in both `en` and `zh-CN`. Specs that introduce or change user-visible strings call this out explicitly in the Plan, with a Test item that checks the locale files. The `leanspec-development` skill's [I18N.md](../leanspec-development/references/I18N.md) is the canonical reference.
+If the overlay introduces an additional issue-body section or label (e.g. `Provider impact`, `Schema impact`, `provider-impact`, `schema-impact`, `i18n`), apply it. The repo's CLAUDE.md or sister skill is authoritative for which extras it requires.
 
 ## When to use this skill
 
 Use when:
 
-- A change touches multiple files or areas.
+- A change touches multiple files or subsystems.
 - Multiple stakeholders need alignment before implementation.
 - The AI needs explicit boundaries for a non-trivial feature.
 - Work will span multiple PRs (parent + child specs).
-- The change touches the provider abstraction, the schema in `schemas/`, the CLI surface, the MCP surface, or anything else externally observable — those are *always* spec-worthy regardless of diff size.
+- The change touches an externally observable contract — schema, CLI surface, public API, provider trait, event manifest — *regardless of diff size*. Consumer repos may name additional always-spec surfaces in their CLAUDE.md or sister skill; honour them.
 
 Skip when:
 
@@ -56,7 +61,19 @@ Skip when:
 - A one-line bug fix with an obvious reproduction. Just open a PR with `Fixes #existing`.
 - The feature already has a spec issue — extend that spec, don't create another.
 
-**Default is spec, not trivial.** If invocation of this skill is itself the decision — the user said "spec this" or the change clearly isn't a typo/one-liner — proceed straight to Discover. Do not stop to confirm spec-vs-`trivial`.
+**Default is spec, not trivial.** If invocation of this skill is itself the decision — the user said "spec this" or the change clearly isn't a typo/one-liner — proceed straight to Discover. Do not stop to confirm spec-vs-`trivial`. The "Skip when" list is a self-veto for unambiguously trivial diffs; everything else is a spec by default. `trivial` is a sparingly-used escape hatch (see the repo's `*-dev-process` and `*-pre-push` sister skills), not a 50/50 fork to ask about.
+
+## Setup
+
+| Parameter | Default | Example override |
+|-----------|---------|-----------------|
+| **Topic** | _(required)_ | `"session timeout"`, `"fix heartbeat race"` |
+| **Scope** | Inferred from codebase | `"only stiglab"`, `"only the cli"` |
+| **Priority** | `medium` | `critical`, `high`, `low` |
+| **Labels** | Auto from type + area | `"spec, feat, area:<sub>"` |
+| **Parent** | None | `#42` (umbrella issue) |
+
+If the user says "spec session timeout", start immediately. Do not ask clarifying questions unless the topic is genuinely ambiguous — and do not ask whether the change should be a `trivial`-labeled PR instead. Invocation of this skill *is* the decision; the "Skip when" list above is the only place that question gets re-litigated, and only for unambiguously trivial diffs.
 
 ## Workflow
 
@@ -70,13 +87,13 @@ Skip when:
 
 ### 1. Discover
 
-Before writing anything:
+Before writing anything, understand what exists:
 
-- Search existing issues on `codervisor/lean-spec` for related or duplicate specs.
-- Search the legacy `specs/` directory for prior work on the same topic (`grep -lri "<topic>" specs/`). Pre-migration specs are historical context, not the spec; quote intent from them when relevant.
-- Read the relevant section of the `README.md` and any `docs/` material to ground the spec in lean-spec's existing commitments.
-- Grep the codebase for types, modules, files related to the topic.
+- Search existing GitHub issues on the target repo for related or duplicate specs.
+- Grep the codebase for types, functions, modules related to the topic.
+- Read key files that will be affected.
 - Check git log for recent changes in the area.
+- Read the repo's `CLAUDE.md` and any canonical product doc it points at (e.g. an architecture doc, an ADR, a `docs/<product>-spec.md`) — they ground the spec in existing commitments and identify always-spec surfaces.
 
 If a related spec issue already exists, reference it — don't duplicate.
 
@@ -84,7 +101,7 @@ If a related spec issue already exists, reference it — don't duplicate.
 
 Read [references/spec-format.md](references/spec-format.md) for the section-by-section format guide.
 
-**Don't hard-wrap prose, list items, or blockquote lines.** GitHub renders issue and comment bodies with `breaks: true` — every newline inside a paragraph, list item, or blockquote becomes a `<br>`, producing visible mid-sentence breaks. Each paragraph, list item, and blockquote line is a single long line; only blank lines separate paragraphs, and each new bullet/quote line starts on its own line. Fenced code blocks and tables preserve formatting and are unaffected. Headings are single-line by markdown's own rules.
+**Don't hard-wrap prose, list items, or blockquote lines.** GitHub renders issue and comment bodies with `breaks: true` — every newline inside a paragraph, list item, or blockquote becomes a `<br>`, producing visible mid-sentence breaks. Source files in many repos wrap at ~70–100 columns; **issue bodies must not**. Each paragraph, list item, and blockquote line is a single long line; only blank lines separate paragraphs, and each new bullet/quote line starts on its own line. Fenced code blocks and tables preserve formatting and are unaffected. Headings are single-line by markdown's own rules.
 
 Draft the issue body using the lean-spec structure:
 
@@ -93,7 +110,7 @@ Draft the issue body using the lean-spec structure:
 Problem statement and motivation. Why does this matter?
 
 ## Design
-Technical approach: data flow, types, architecture decisions.
+Technical approach: data flow, API changes, architecture decisions.
 Keep it high-level — intent, not implementation.
 
 ## Plan
@@ -103,18 +120,13 @@ Keep it high-level — intent, not implementation.
 
 ## Test
 - [ ] How to verify each plan item
-- [ ] Include: unit tests, integration tests, manual checks,
-      i18n locale parity where applicable
-
-## Provider impact
-<!-- omit only if the change provably touches no provider surface -->
-- Types added/removed/renamed
-- Cross-backend semantics changed
-- Migration path for existing markdown / github backends
+- [ ] Include: unit tests, integration tests, manual checks
 
 ## Notes
 Tradeoffs, context, references. Optional — omit if empty.
 ```
+
+Consumer repos may require additional sections (e.g. `## Provider impact`, `## Schema impact`, `## Worked example`) — read the repo's CLAUDE.md / sister skill for the full list and the rules for when each section is required vs. optional. Templates under [templates/](templates/issue-spec-template.md) cover the universal shape; consumer-repo overlays may extend the template.
 
 **Context economy check**: If the issue body exceeds ~2000 tokens, split it:
 
@@ -125,13 +137,13 @@ Tradeoffs, context, references. Optional — omit if empty.
 
 ### 3. Align
 
-Add an **Alignment** section to the issue body:
+Add an **Alignment** section to the issue body (this extends lean-spec for human-AI collaboration):
 
 ```markdown
 ## Alignment
 
 ### Human decides
-- [ ] Architectural tradeoffs, scope, provider semantics, go/no-go
+- [ ] Architectural tradeoffs, scope, UX, go/no-go
 
 ### AI implements
 - [ ] Concrete code tasks tied to Plan items
@@ -157,34 +169,27 @@ Before creating the issue, self-check:
 - [ ] Design captures intent, not implementation details
 - [ ] Plan items are concrete and independently verifiable
 - [ ] Test items map to Plan items
-- [ ] `## Provider impact` section is present (or the spec provably touches no provider surface)
-- [ ] If user-visible strings are introduced or changed, the Plan and Test sections cover both `en` and `zh-CN`
+- [ ] Any repo-specific required section (e.g. `## Provider impact`, `## Schema impact`) is present, or the spec provably doesn't touch that surface
 - [ ] Human/AI boundaries are explicit — no "figure it out" items
 - [ ] No duplicate of an existing issue
 - [ ] Dependencies are referenced by issue number
 
 ### 5. Publish
 
-Create the issue using `mcp__github__issue_write` against `codervisor/lean-spec`:
+Create the issue using `mcp__github__issue_write` against the consumer repo:
 
 **Title format**: `spec(<area>): <short description>`
 
-Examples:
-
-- `spec(provider): github provider — issue CRUD via MCP`
-- `spec(cli): leanspec migrate accepts --to=github`
-- `spec(ui): dependency graph view shows cross-backend edges`
-- `spec(docs): document provider switching`
+`<area>` is drawn from the consumer repo's area-label taxonomy — read the `*-dev-process` sister skill (or the repo's CLAUDE.md if the sister skill defers) for the canonical list. Examples observed across consumer repos: `spec(stiglab): add session timeout`, `spec(provider): github provider — issue CRUD via MCP`, `spec(schema): add api/observe action type`.
 
 **Labels**: Apply via the issue creation:
 
-- `spec` — always
+- `spec` — always, marks this as a spec issue
 - Type: `feat`, `fix`, `refactor`, `perf`
-- Area (see taxonomy below)
+- Area (consumer-repo taxonomy)
 - Priority: `priority:critical`, `priority:high`, `priority:medium`, `priority:low`
 - Status: `draft` (initial state)
-- `provider-impact` — apply whenever the spec includes a non-empty `## Provider impact` section. This is the discoverability signal for "which specs touch the provider seam?". Whether the change is breaking for the markdown backend, the github backend, or both is recorded inside the section.
-- `i18n` — apply whenever the spec adds or changes a user-visible string.
+- Any consumer-repo cross-cutting labels (e.g. `provider-impact`, `schema-impact`, `i18n`) when the corresponding overlay section is non-empty
 
 **Sub-issues**: If this is a child of a parent spec, link it using `mcp__github__sub_issue_write`.
 
@@ -195,64 +200,51 @@ Examples:
 - Any open questions that need human decisions
 - Sub-issue links if the spec was split
 
-## Area label taxonomy (lean-spec repo)
-
-Pick one or more. The taxonomy follows the package layout in `packages/`, the Rust crates in `rust/`, and the cross-cutting concerns:
-
-- `area:cli` — `packages/cli/` (TypeScript wrapper) and `rust/leanspec-cli/` (Rust binary)
-- `area:ui` — `packages/ui/` (web UI)
-- `area:desktop` — `packages/desktop/` (Tauri app)
-- `area:http-server` — `packages/http-server/` and `rust/leanspec-http/`
-- `area:core` — `rust/leanspec-core/` (types, provider interface, business logic)
-- `area:provider` — provider abstraction itself (markdown, github, future ADO/Jira). Anything that adds or changes the provider trait, its types, or how the rest of the app consumes it lives here.
-- `area:mcp` — `@leanspec/mcp` server
-- `area:schemas` — `schemas/` JSON schemas
-- `area:docs` — `docs/`, `docs-site/`, `README.md`
-- `area:infra` — `.github/workflows/`, `scripts/`, `deploy/`, `docker/`, `railway.json`, publishing pipeline
-- `area:agents` — `.agents/skills/`, `.claude/`, `.gemini/`, agent configuration
-
-A spec that legitimately spans two areas should be split unless the change is genuinely a single contract crossing the seam (e.g. a new field flowing from `area:core` types through `area:ui` rendering — that's one spec, two area labels). A spec touching three or more areas is almost always two specs hiding in a trench coat.
-
 ## Status Lifecycle via Labels
 
+GitHub issue state (open/closed) combined with status labels:
+
 ```
-open + draft  →  open + planned  →  open + in-progress  →  closed
+open + draft  →  open + planned  →  open + in-progress  →  closed (complete)
 ```
 
 - **draft**: Spec created, open questions may remain. AI wrote it, human hasn't reviewed.
 - **planned**: Human reviewed, decisions made, ready for implementation. Remove `draft`, add `planned`.
-- **in-progress**: Someone/something is actively working (PR opened). Remove `planned`, add `in-progress`. *Currently manual* on this repo — no `pr-spec-sync` workflow yet (see `lean-spec-pr-lifecycle`).
+- **in-progress**: Someone/something is actively working (PR opened). Remove `planned`, add `in-progress`. Some consumer repos automate this transition via a `pr-spec-sync.yml` GitHub Actions workflow; others handle it manually — check the repo's `*-pr-lifecycle` sister skill.
 - **closed**: All plan items done, tests passing. PR merge with `Closes #N` closes it automatically.
 
-**Key rule**: `draft → planned` is the human-AI alignment gate. The AI does not flip this label unprompted.
+**Key rule**: `draft → planned` is the human-AI alignment gate. A spec moves to `planned` only after a human reviews it and resolves open questions. The AI does not flip this label unprompted.
 
 ## Spec Relationships via Sub-Issues
 
-| Relationship    | GitHub mechanism                                        | When to use                                        |
-|-----------------|---------------------------------------------------------|----------------------------------------------------|
-| **Parent/Child**| Sub-issues (`mcp__github__sub_issue_write`)             | Large feature decomposed into pieces               |
-| **Depends On**  | Issue body reference (`depends on #N`)                  | Spec blocked until another finishes                |
-| **Related**     | Issue body reference (`related: #N`)                    | Loosely connected specs                            |
+Use GitHub sub-issues for parent/child decomposition:
+
+| Relationship    | GitHub mechanism                                        | When to use                              |
+|-----------------|---------------------------------------------------------|------------------------------------------|
+| **Parent/Child**| Sub-issues (`mcp__github__sub_issue_write`)             | Large feature decomposed into pieces     |
+| **Depends On**  | Issue body reference (`depends on #N`)                  | Spec blocked until another finishes      |
+| **Related**     | Issue body reference (`related: #N`)                    | Loosely connected specs                  |
 
 **Decision rule**: Remove the dependency — does the spec still make sense? If no → sub-issue (child). If yes but blocked → depends on.
 
-**Example decomposition:**
+**Example decomposition** (shape, not specific to any one repo):
 
 ```
-spec(provider): github provider v1                ← parent issue
-├── spec(provider): issue CRUD via MCP             ← sub-issue
-├── spec(provider): label-to-frontmatter mapping   ← sub-issue
-├── spec(provider): sub-issue → parent/child       ← sub-issue
-└── spec(cli): leanspec init --provider=github    ← sub-issue
+spec(<area>): umbrella feature                ← parent issue
+├── spec(<area>): concern A                   ← sub-issue
+├── spec(<area>): concern B                   ← sub-issue
+└── spec(<other-area>): UI surface for A+B    ← sub-issue
 ```
+
+When a contract under a repo's architectural rule splits work across two subsystems (e.g. a back-end producer + a front-end consumer of an event), use the parent-plus-children shape: one parent spec captures the end-to-end slice, one child spec per subsystem captures its half. The contract lives in the parent's Plan; each child scopes to a single area label. Producer and consumer halves can land in separate PRs as long as both close before the parent does — but the parent's Plan should require a contract test that fails until both halves exist.
 
 ## Guidance
 
 - **Small is better.** A 500-token spec that captures intent clearly beats a 3000-token spec that tries to cover everything. Split into sub-issues early.
-- **Discover first.** Always search existing issues — and the legacy `specs/` directory — before creating. Duplicate specs create confusion.
+- **Discover first.** Always search existing issues before creating. Duplicate specs create confusion.
 - **Status labels reflect reality.** Don't label `planned` if decisions are still open. Don't label `in-progress` until a PR is open.
 - **One concern per issue.** If a spec covers two independent changes, split into sub-issues with a shared parent.
-- **Reference code, not concepts.** Once code exists, point to actual types, functions, files — not abstract ideas.
+- **Reference code, not concepts.** Point to actual types, functions, files — not abstract ideas. Use concrete paths like `crates/<sub>/src/...` or `packages/<pkg>/src/...` rather than "the foo module."
 - **Open questions are alignment points.** These are where AI must stop and ask a human. Make them explicit, specific, and include the impact of each decision.
 - **Comments are the decision record.** When a human resolves an open question, they comment on the issue. The thread becomes the audit trail.
 - **Use specs for alignment, not for everything.** Regular bugs and small tasks don't need specs. Use specs when: multiple stakeholders need alignment, intent needs persistence, or the AI needs clear boundaries.
@@ -262,35 +254,35 @@ spec(provider): github provider v1                ← parent issue
 Once a spec moves to `planned`:
 
 1. Create a branch referencing the issue: `claude/spec-<N>-<slug>` (Claude-owned) or any name (human-owned).
-2. Follow the SDD loop in `lean-spec-dev-process`.
-3. Pre-push via `lean-spec-pre-push` (includes a spec-link check, `pnpm typecheck`, `pnpm test`, and `cargo clippy -- -D warnings`).
+2. Follow the SDD loop in the repo's `*-dev-process` sister skill.
+3. Pre-push via the repo's `*-pre-push` sister skill (which typically includes a spec-link check plus the repo's typecheck / lint / test gates).
 4. PR body must include `Closes #N` (slice complete) or `Part of #N` (scaffolding).
-5. After merge, see `lean-spec-pr-lifecycle` for Plan-item ticks, parent-spec maintenance, and CHANGELOG follow-through.
+5. On PR open, the repo's `pr-spec-sync` workflow (if present) flips the issue to `in-progress`; on merge GitHub auto-closes `Closes #N` issues and the merger ticks Plan items on `Part of #N` parents manually. See `*-pr-lifecycle`.
 
-## Relationship to legacy file-based specs
+## Repo-agnostic by construction; consumer overlay is required
 
-The `specs/` directory contains pre-migration specs. After migration (see `scripts/migrate-specs-to-issues.ts`):
+This skill is the **methodology**; it intentionally does not name a repo, an area taxonomy, or a set of cross-cutting labels. Every consumer repo overlays those via:
 
-- Specs with status `complete`, `archived`, or `deferred` remain as files. They're the historical record.
-- Specs with status `planned`, `in-progress`, or `draft` have been migrated to GitHub issues. The files remain as a frozen snapshot but the **issue is canonical**.
-- New work always starts as a GitHub issue. Do not create new `specs/NNN-slug/` directories on this repo.
+- Its `CLAUDE.md` (repo-specific principles, target GitHub slug, always-spec surfaces).
+- Its `*-dev-process` sister skill (area-label taxonomy, spec-vs-`trivial` gate, SDD loop).
+- Its `*-pre-push` and `*-pr-lifecycle` sister skills (which gates run pre-push and which automation runs post-push).
+- Optionally an additional product spec doc (e.g. `docs/<product>-spec.md`, an architecture ADR set) that the repo's CLAUDE.md points at.
 
-When you're searching for prior work, search both: GitHub issues (current) and `specs/` (history). When you're writing new specs, write only as GitHub issues.
-
-## Relationship to Onsager / Duhem `issue-spec`
-
-This skill and the `issue-spec` skills on `onsager-ai/onsager` and `onsager-ai/duhem` are **parallel, not shared**. Each is scoped to its own repo, with its own area taxonomy and architectural invariants. The shared methodology is the lean-spec SDD methodology itself — that's what this repo implements.
+Treat reading those as part of step 1 (Discover). Don't draft a spec without having loaded the consumer repo's overlay context first — a spec that names the wrong area label, misses a required section, or proposes something the repo's seam / schema / provider rule forbids is a spec the human has to rewrite.
 
 ## References
 
-| Reference                                          | When to read                                |
-|----------------------------------------------------|---------------------------------------------|
-| [references/spec-format.md](references/spec-format.md) | Always — section-by-section guide           |
-| [../leanspec-development/references/I18N.md](../leanspec-development/references/I18N.md) | Specs that touch user-visible strings       |
-| [../leanspec-development/references/RULES.md](../leanspec-development/references/RULES.md) | Mandatory project rules                     |
+| Reference                                              | When to read                                              |
+|--------------------------------------------------------|-----------------------------------------------------------|
+| [references/spec-format.md](references/spec-format.md) | Always — section-by-section guide with worked examples    |
+| Repo's `CLAUDE.md`                                     | Always — repo-specific principles + always-spec surfaces  |
+| Repo's `*-dev-process` sister skill                    | Always — area-label taxonomy + spec-vs-`trivial` gate     |
+| Repo's `*-pr-lifecycle` sister skill                   | When publishing — does the repo automate `pr-spec-sync`?  |
 
 ## Templates
 
-| Template                                                | Purpose                                |
-|---------------------------------------------------------|----------------------------------------|
-| [templates/issue-spec-template.md](templates/issue-spec-template.md) | Issue body template — copy and fill |
+| Template                                                             | Purpose                                                  |
+|----------------------------------------------------------------------|----------------------------------------------------------|
+| [templates/issue-spec-template.md](templates/issue-spec-template.md) | Universal issue body template — copy and fill            |
+
+Consumer repos may ship an extended template alongside this one (e.g. with a `## Provider impact` or `## Schema impact` block pre-filled). Prefer the consumer-repo extended template when present.

--- a/.agents/skills/issue-spec/references/spec-format.md
+++ b/.agents/skills/issue-spec/references/spec-format.md
@@ -1,6 +1,8 @@
 # Spec Format Reference
 
-Section-by-section guide for writing lean-spec style GitHub issue specs on `codervisor/lean-spec`. Based on the lean-spec SDD methodology applied to lean-spec itself — we dogfood the workflow we ship.
+Section-by-section guide for writing lean-spec style GitHub issue specs. Based on the [lean-spec SDD methodology](https://github.com/codervisor/lean-spec), adapted to use GitHub issues as the sole spec medium.
+
+This reference is repo-agnostic. Consumer repos overlay their area-label taxonomy, custom body sections (e.g. Provider impact, Schema impact), and additional principles via their `CLAUDE.md` and `*-dev-process` / `*-pre-push` / `*-pr-lifecycle` sister skills — read those first.
 
 ## Metadata via GitHub Issue Features
 
@@ -10,7 +12,7 @@ No YAML frontmatter — all metadata lives in native GitHub features:
 |--------------------|-----------------------|----------------------------------------------|
 | `status`           | Labels                | `draft`, `planned`, `in-progress`            |
 | `priority`         | Labels                | `priority:high`                              |
-| `tags`             | Labels                | `area:provider`, `feat`                      |
+| `tags`             | Labels                | `area:<subsystem>`, `feat`                   |
 | `depends_on`       | Issue body reference  | `depends on #42`                             |
 | `parent/child`     | Sub-issues            | Created via `mcp__github__sub_issue_write`   |
 | `assignee`         | Issue assignee        | `@username`                                  |
@@ -32,9 +34,9 @@ Apply labels when creating the issue:
 - `refactor` — restructuring without behavior change
 - `perf` — performance improvement
 
-**Area** (pick one or more — see SKILL.md "Area label taxonomy"):
+**Area** (pick one or more):
 
-- `area:cli`, `area:ui`, `area:desktop`, `area:http-server`, `area:core`, `area:provider`, `area:mcp`, `area:schemas`, `area:docs`, `area:infra`, `area:agents`
+Drawn from the consumer repo's area taxonomy — read the repo's `*-dev-process` sister skill (or `CLAUDE.md`) for the canonical list. Examples observed across consumer repos: `area:spine`, `area:dashboard`, `area:cli`, `area:ui`, `area:provider`, `area:schema`, `area:runtime`, `area:judge`, `area:docs`, `area:infra`. Respect each repo's architectural invariants when picking the area: a spec that crosses two areas should usually be split into per-area child specs with a shared parent.
 
 **Priority** (pick one):
 
@@ -49,12 +51,9 @@ Apply labels when creating the issue:
 - `planned` — human reviewed, decisions made, ready for implementation
 - `in-progress` — actively being worked on (PR open)
 
-**Cross-cutting:**
+**Cross-cutting (consumer-repo overlay):**
 
-- `provider-impact` — apply whenever the spec includes a non-empty `## Provider impact` section. Covers *any* change to the provider abstraction, the provider trait, or anything that crosses the markdown / github backend seam. The label is the discoverability signal for "which specs touch the provider seam?".
-- `i18n` — apply whenever the spec adds or changes a user-visible string. Both `en` and `zh-CN` are mandatory; this label flags the spec for the locale-file review pass.
-- `migrated-from-file` — applied automatically by `scripts/migrate-specs-to-issues.ts` for specs that originated as files in `specs/`. Helps separate migration noise from net-new work.
-- `trivial` (PR-only label, not a spec label) — opts a PR out of the spec-link requirement. See `lean-spec-dev-process`.
+Some consumer repos define additional discoverability labels for cross-cutting concerns — e.g. `provider-impact` for specs that touch a provider seam, `schema-impact` for schema changes, `i18n` for user-visible string changes, `trivial` (PR-only) for specs-not-required. Apply the ones that exist in the target repo; the repo's CLAUDE.md / sister skill is authoritative.
 
 ### Status Lifecycle
 
@@ -68,7 +67,7 @@ The `draft → planned` transition is the **human-AI alignment gate**. Only a hu
 - Design approach is approved
 - Scope and priority are accepted
 
-`planned → in-progress` happens **manually on this repo** when a PR referencing the issue opens. (Onsager has automation for this; lean-spec does not yet — that's itself a candidate spec.) See `lean-spec-pr-lifecycle`.
+`planned → in-progress` happens **automatically** on PR open in repos that ship a `pr-spec-sync.yml` workflow, and **manually** in repos that don't. Check the repo's `*-pr-lifecycle` sister skill.
 
 `in-progress → closed` happens automatically on PR merge with a `Closes #N` keyword. `Part of #N` PRs don't close the parent; the merger ticks the parent's Plan checkboxes manually.
 
@@ -78,149 +77,201 @@ The `draft → planned` transition is the **human-AI alignment gate**. Only a hu
 
 **Purpose**: Why does this work matter? What problem does it solve?
 
-**Good overview** (note: prose, list items, and blockquote lines are *not* hard-wrapped — GitHub renders single newlines as `<br>` in issue bodies; see SKILL.md step 2):
+**Good overview** (note: prose, list items, and blockquote lines are *not* hard-wrapped — GitHub renders single newlines as `<br>` in issue bodies):
 
 ```markdown
 ## Overview
 
-Today, lean-spec's only supported backend is markdown files in `specs/`. Users who already track work in GitHub Issues, ADO, or Jira have to choose between adopting lean-spec's filesystem layout or forgoing the framework entirely.
-
-This adds a github provider so lean-spec can read and write specs as GitHub issues. The CLI, MCP, and UI all stay identical — the user picks a backend in config, and the rest of the product behaves the same.
+Sessions in `WAITING_INPUT` state can hang indefinitely if the user disconnects. This wastes agent capacity and leaves stale sessions in the dashboard. We need a configurable timeout that transitions idle sessions to `FAILED` after a period of inactivity.
 ```
 
-**Bad overview:** describes the solution before the problem; spends two paragraphs on context already in the README; mentions a specific function name.
+**Bad overview:**
+
+```markdown
+## Overview
+
+Add a timeout feature to sessions.
+```
+
+The bad version says *what* but not *why*. The AI has no context to make tradeoff decisions during implementation.
+
+**Guidelines:**
+
+- 2-4 sentences. Problem → impact → what we need.
+- Reference specific code/behavior when possible.
+- Don't describe the solution here — that's Design's job.
 
 ### Design
 
-**Purpose**: Capture intent, not implementation. A reader should understand the *shape* of the change without reading the diff.
+**Purpose**: How should this work? What's the technical approach?
 
-Cover:
+**Write intent, not implementation:**
 
-- Data flow at intent level
-- Type changes (link to specific files: `packages/ui/src/types/specs.ts`, `rust/leanspec-core/src/...`)
-- Provider trait changes (if any)
-- Out-of-scope: what this spec deliberately doesn't do
+```markdown
+## Design
 
-Don't:
+Each session gets an inactivity timer that resets on any WebSocket message. When the timer expires:
+1. Emit a `SessionTimeoutWarning` event 5 minutes before deadline
+2. Transition state to `Failed` with reason `session_timeout`
+3. Preserve all session output collected before timeout
 
-- Quote 50 lines of code
-- Specify exact function signatures (those go in the PR)
-- Describe how to write the test (that's `## Test`)
+The timeout duration is server-configurable via environment variable. Per-session overrides are out of scope for now.
+```
+
+**Guidelines:**
+
+- Describe data flow, state changes, API surface — not line-by-line code.
+- Include what's explicitly **out of scope** to prevent scope creep.
+- If design is complex, create child sub-issues for subsections.
+- Reference existing architecture when relevant.
+- Respect the consumer repo's architectural invariants (e.g. event-bus seam rules, provider-agnostic core, holistic verification). The repo's `CLAUDE.md` is authoritative.
 
 ### Plan
 
-A checklist of concrete deliverables. Each item:
-
-- Starts with a verb
-- Is independently verifiable
-- Has a single owner (AI or human, not both)
-- Order reflects implementation sequence (top-down dependencies)
-
-A 2–6 item Plan is healthy. A Plan with 12 items is two specs hiding in a trench coat — split it.
-
-### Test
-
-How each Plan item is verified. Map 1:1 to Plan items where possible. Include:
-
-- Unit tests (file path / function name) — Vitest for TypeScript, `#[cfg(test)]` for Rust
-- Integration tests
-- `pnpm typecheck` — never skip before marking complete
-- `pnpm pre-push` — typecheck + clippy
-- `pnpm pre-release` — full build + test + lint, when shipping a release
-- i18n parity check — both `en` and `zh-CN` updated when user-visible strings change
-- Manual checks (only when automation is genuinely impossible)
-
-### Provider impact
-
-Required when the change touches the provider abstraction (`area:provider`), the types in `packages/ui/src/types/specs.ts`, the provider trait in `rust/leanspec-core/`, or anything else externally observable across backends.
-
-Format:
-
-```markdown
-## Provider impact
-
-- Types added: `SpecBackend`, `ProviderConfig.token: string | null`
-- Types renamed: none
-- Types removed: none
-- Trait changes: `Provider::list_specs()` now returns `Result<Vec<LightweightSpec>>` (was `Vec<LightweightSpec>`)
-- markdown backend semantics: unchanged
-- github backend semantics: new
-- Migration path: existing markdown projects continue to work; users opt in to github via `lean-spec init --provider=github` or by editing `.lean-spec/config.json`
-- Breaking change? no — markdown remains the default; github is additive
-```
-
-Apply the `provider-impact` label whenever this section is present. Whether the change is breaking is a separate signal answered by the `Breaking change?` line. If `Breaking change? yes`, also add a CHANGELOG entry on merge.
-
-### i18n impact
-
-Required (inline in Plan + Test) when the spec adds or changes a user-visible string. Both `en` and `zh-CN` locale files must be updated in the same PR — this is enforced by `leanspec-development`'s I18N rules.
-
-Format (inline, not a separate top-level section):
+**Purpose**: Concrete deliverables as a checklist. Each item is independently verifiable.
 
 ```markdown
 ## Plan
-- [ ] Add `--filter` flag handling in `packages/cli/src/commands/run.ts`
-- [ ] Update `locales/en.json` with `cli.run.filter.help`
-- [ ] Update `locales/zh-CN.json` with `cli.run.filter.help`
 
-## Test
-- [ ] Vitest unit test for filter parsing
-- [ ] CI i18n parity check passes (both locales have the new key)
+- [ ] Add `SESSION_TIMEOUT` env var to server config (default: 30m)
+- [ ] Implement per-session inactivity timer in `SessionManager`
+- [ ] Add `SessionTimeoutWarning` event type
+- [ ] Emit warning event 5 minutes before timeout
+- [ ] Transition `WaitingInput → Failed` on timeout expiry
+- [ ] Preserve session output on timeout (no data deletion)
+- [ ] Add timeout info to `GET /api/sessions/:id` response
 ```
+
+**Guidelines:**
+
+- Each item starts with a verb: Add, Implement, Update, Remove, Fix.
+- Items should be small enough to verify in isolation.
+- Order reflects implementation sequence.
+- If a plan has more than ~10 items, the spec is too big — split into sub-issues.
+- Checkboxes serve as progress tracking on the issue itself; tick them manually as `Part of #N` PRs merge (see the repo's `*-pr-lifecycle` sister skill).
+
+### Test
+
+**Purpose**: How to verify each plan item is done correctly.
+
+```markdown
+## Test
+
+- [ ] Unit test: config parses valid duration strings, rejects invalid
+- [ ] Unit test: timer resets on incoming message
+- [ ] Integration test: session transitions to Failed after timeout
+- [ ] Integration test: warning event emitted 5 minutes before timeout
+- [ ] Integration test: session output preserved after timeout
+- [ ] Manual: dashboard shows timeout state and warning indicator
+```
+
+**Guidelines:**
+
+- Each test item maps to one or more plan items.
+- Specify test type: unit, integration, manual, type check, lint.
+- Include negative cases: "rejects invalid", "does not delete".
+- For manual tests, describe what to check — not exact click paths.
+- Consumer repos may require additional test classes (e.g. i18n locale parity, schema validation) — read the repo's CLAUDE.md / sister skill.
 
 ### Alignment
 
-Three sub-sections:
+**Purpose**: Explicit partition of work between human and AI. This section extends the lean-spec format for human-AI collaborative development.
 
-#### Human decides
+```markdown
+## Alignment
 
-Decisions requiring judgment, scope authority, or domain knowledge the AI doesn't have. Examples:
+### Human decides
+- [ ] Timeout default value (proposed: 30m)
+- [ ] Whether to show UI warning (toast vs. banner)
+- [ ] Behavior on network partition
 
-- Which of two type shapes to commit to
-- Whether a behavior is in scope for this spec or a follow-up
-- Whether a breaking change is acceptable now vs deferred
+### AI implements
+- [ ] Config parsing and validation
+- [ ] Timer logic in SessionManager
+- [ ] Event types and emission
+- [ ] State transition + database update
+- [ ] Unit and integration tests per Test section
 
-#### AI implements
+### Open questions
+> Should timed-out sessions be retryable, or must the user create a new task?
+> Impact: changes whether final state is `Failed` or `Pending`.
+```
 
-Concrete code tasks tied to Plan items. Examples:
+**Guidelines:**
 
-- "Add `--filter` flag handling in `packages/cli/src/commands/run.ts`"
-- "Implement `GithubProvider::list_specs` in `rust/leanspec-core/src/providers/github.rs`"
-
-#### Open questions
-
-`>` blockquoted questions that block `draft → planned`. Each must:
-
-- State the question
-- Note the impact (which Plan items are affected)
-- Include enough context that a human can answer without rereading the whole spec
+- Every Plan item maps to exactly one of: "Human decides" or "AI implements."
+- Human items are decisions/tradeoffs. AI items are execution.
+- Open questions block implementation — they must be resolved (via issue comments) before the `draft → planned` label transition.
+- Once a human answers a question in a comment, update the Alignment section and record the decision.
 
 ### Notes
 
-Optional. Tradeoffs, related issues, prior art. Omit if empty.
+**Purpose**: Context, tradeoffs, references — anything that doesn't fit elsewhere.
 
-When migrating from a legacy file-based spec, the original file path goes in Notes (e.g. `Migrated from specs/110-project-aware-agents-generation/README.md`) so the historical context is one click away.
+```markdown
+## Notes
 
-## Sub-issue decomposition
-
-When a spec exceeds ~2000 tokens or covers more than one independent concern, split it into a parent + child specs:
-
-```
-spec(provider): github provider v1                ← parent
-├── spec(provider): issue CRUD via MCP             ← child sub-issue
-├── spec(provider): label-to-frontmatter mapping   ← child sub-issue
-├── spec(provider): sub-issue → parent/child       ← child sub-issue
-└── spec(cli):     leanspec init --provider=github ← child sub-issue
+- Considered per-session timeout overrides via API, but deferred to keep scope small. Can add in a follow-up spec.
+- The timeout timer approach uses a per-session async timer. At 100+ concurrent sessions this may need optimization.
+- Related: #23, #31
 ```
 
-The parent spec carries the overarching intent and a high-level Plan that's a list of the children. Each child is independently implementable and has its own Design, Plan, Test, Provider impact, Alignment.
+**Guidelines:**
 
-Use `mcp__github__sub_issue_write` to attach children to the parent.
+- Tradeoffs considered and why you chose this approach.
+- Performance or scalability concerns for future reference.
+- Links to related issues, PRs, or external resources.
+- Keep it brief — notes are context, not a second design section.
+- Omit this section entirely if there's nothing to note.
 
-## Cross-references
+### Consumer-repo overlay sections
 
-- `README.md` — what lean-spec is and isn't; cite when grounding a spec
-- `.agents/skills/leanspec-development/SKILL.md` — dev/CI/publish commands; reference rather than duplicate
-- `.agents/skills/leanspec-development/references/RULES.md` — mandatory project rules
-- `.agents/skills/leanspec-development/references/I18N.md` — i18n locations and patterns
-- `specs/` — frozen historical specs (pre-migration); search for prior intent, do not author new files here
+Some consumer repos require additional sections in the issue body. Apply the ones that exist in the target repo:
+
+- **`## Provider impact`** (lean-spec) — required whenever a change touches the provider abstraction or anything crossing the markdown / github backend seam. Captures types added/removed/renamed, trait changes, per-backend semantics, migration path, breaking?-flag.
+- **`## Schema impact`** (Duhem) — required whenever a change touches the Verification Definition format, action-type catalog, runtime expressions, judge semantics, or any externally observable contract. Captures fields added/removed/renamed, semantics changes, migration path for in-flight definitions, breaking?-flag.
+- **`## Worked example`** (Duhem) — required when a spec introduces or modifies user-visible product surface. A minimal Verification Definition (or link to one) that exercises the surface end-to-end.
+- **Reach plan items** (Onsager) — when a spec introduces a new user-facing primitive, the Plan must include nav entry, first-run flow, empty-state CTAs, and auth gating.
+
+The repo's CLAUDE.md / sister skill is authoritative for which extras it requires. Drop a section only if the change provably doesn't touch its surface.
+
+## Context Economy Rules
+
+Smaller specs produce better results — for both AI implementation and human review:
+
+| Issue body size | Action                                            |
+|-----------------|---------------------------------------------------|
+| < 500 tokens    | Good for bug fixes and small changes              |
+| 500–2000 tokens | Standard spec — covers most features              |
+| > 2000 tokens   | **Split into parent + sub-issues**                |
+
+**How to split:**
+
+1. Create a parent issue with Overview + high-level Plan listing the children.
+2. Create child issues via `mcp__github__sub_issue_write`, one per independent concern.
+3. Each child has its own Design, Plan, Test, Alignment sections.
+4. Parent tracks overall progress; children track individual concerns.
+
+**Example:**
+
+```
+#50 spec(<area>): umbrella feature                ← parent
+  ├── #51 spec(<area>): concern A                 ← sub-issue
+  ├── #52 spec(<area>): concern B                 ← sub-issue
+  └── #53 spec(<other-area>): UI surface for A+B  ← sub-issue
+```
+
+## Title Convention
+
+```
+spec(<area>): <short description in imperative mood>
+```
+
+`<area>` is one of the consumer repo's `area:*` labels with the `area:` prefix dropped. Examples across consumer repos:
+
+- `spec(stiglab): add session timeout for idle sessions`
+- `spec(provider): github provider — issue CRUD via MCP`
+- `spec(schema): add api/observe action type`
+- `spec(dashboard): show real-time node heartbeat status`
+- `spec(judge): three-state verdict aggregation rules`
+- `spec(infra): pin CI action versions to SHAs`

--- a/.agents/skills/issue-spec/templates/issue-spec-template.md
+++ b/.agents/skills/issue-spec/templates/issue-spec-template.md
@@ -1,8 +1,7 @@
-<!-- Issue body template for lean-spec style spec issues on codervisor/lean-spec -->
+<!-- Issue body template for lean-spec style spec issues -->
 <!-- Title: spec(<area>): <short description> -->
 <!-- Labels: spec, <type>, area:<area>, priority:<level>, draft -->
-<!-- Plus provider-impact if the change touches the provider seam -->
-<!-- Plus i18n if the change adds or changes a user-visible string -->
+<!-- Consumer-repo overlay labels (apply when relevant): provider-impact, schema-impact, i18n -->
 
 ## Overview
 
@@ -10,32 +9,23 @@
 
 ## Design
 
-<!-- Technical approach at intent level. Data flow, types, architecture decisions — not line-by-line code. Include what's explicitly OUT OF SCOPE. Respect lean-spec's invariants: provider-agnostic core, identical CLI/MCP/UI behavior across backends, i18n parity. -->
+<!-- Technical approach at intent level. Data flow, state changes, API/schema surface — not line-by-line code. Include what's explicitly OUT OF SCOPE. Respect the consumer repo's architectural invariants (seam rule / provider-agnostic core / holistic verification — see the repo's CLAUDE.md). -->
 
 ## Plan
 
 - [ ] <!-- Verb + concrete deliverable -->
 - [ ] <!-- Each item independently verifiable -->
 - [ ] <!-- Order reflects implementation sequence -->
-- [ ] <!-- If this adds user-visible strings: update locales/en.json AND locales/zh-CN.json -->
 
 ## Test
 
-- [ ] <!-- Vitest unit test or Rust #[cfg(test)] module: file path + what it covers -->
-- [ ] <!-- pnpm typecheck passes -->
-- [ ] <!-- pnpm pre-push passes (typecheck + clippy) -->
-- [ ] <!-- i18n parity verified, if applicable -->
+- [ ] <!-- Test type: what to verify -->
+- [ ] <!-- Maps to plan items above -->
 
-## Provider impact
-
-<!-- Required when this change touches the provider abstraction, the types in packages/ui/src/types/specs.ts, the provider trait in rust/leanspec-core/, or anything else externally observable across backends. Drop the section ONLY if the change provably touches no provider surface (e.g. docs-only edits, CI tweaks, repo hygiene). -->
-
-- Types added / removed / renamed:
-- Trait changes:
-- markdown backend semantics:
-- github backend semantics:
-- Migration path:
-- Breaking change?  yes / no — if yes, add a `CHANGELOG.md` entry on merge (the `provider-impact` label is applied regardless)
+<!-- OPTIONAL OVERLAY SECTIONS (apply when the consumer repo requires them) -->
+<!-- ## Provider impact   (lean-spec — required when the provider seam is touched) -->
+<!-- ## Schema impact     (Duhem — required when the Verification Definition format is touched) -->
+<!-- ## Worked example    (Duhem — required when product surface is introduced) -->
 
 ## Alignment
 
@@ -53,4 +43,4 @@
 
 ## Notes
 
-<!-- Tradeoffs, related issues (#N), references. Omit section if empty. If migrated from a legacy file-based spec, note the original path here. -->
+<!-- Tradeoffs, related issues (#N), references. Omit section if empty. -->


### PR DESCRIPTION
## Summary

Replaces the bespoke `.agents/skills/issue-spec/` with the upstream abstract methodology skill from `onsager-ai/onsager-skills` (PR: onsager-ai/onsager-skills#7), plus a `.upstream-source` marker.

- The universal lean-spec SDD shape (Overview / Design / Plan / Test / Alignment / Notes), status-label lifecycle, sub-issue rules, validate checklist, spec-vs-`trivial` gate — all unchanged in substance.
- The lean-spec-specific overlay (provider-agnostic core + i18n principles, `## Provider impact` section, `provider-impact` / `i18n` labels, the `area:*` taxonomy spanning `packages/` and `rust/`, the `specs/` legacy-snapshot rule, the migration-from-files context) is now described in the abstract skill's overlay section and remains backed by `CLAUDE.md` + the existing `lean-spec-dev-process` / `lean-spec-pre-push` / `lean-spec-pr-lifecycle` / `leanspec-development` sister skills.

## Why

Three near-identical `issue-spec` skills (here, in `onsager-ai/onsager`, in `onsager-ai/duhem`) were diverging through copy-paste. The shared methodology now lives canonically in `onsager-ai/onsager-skills` and syncs back via `npx skills add`. Future edits to the methodology land upstream once instead of three times.

Note: lean-spec keeps its skill root at `.agents/skills/` (rather than `.claude/skills/`) and does not yet ship the `check-skill-edit.sh` hook that Onsager runs. The `.upstream-source` marker is dormant on this repo until that hook (or its lean-spec equivalent) lands — until then it serves as provenance documentation.

Pairs with parallel sync PRs on `onsager-ai/onsager` and `onsager-ai/duhem`.

## Test plan

- [ ] `issue-spec` skill still appears in Claude Code's available-skills list with the right trigger phrases.
- [ ] Drafting a new spec on lean-spec still produces a spec with `## Provider impact` + i18n plan items where relevant — those bits are now overlaid from CLAUDE.md + `lean-spec-dev-process` / `leanspec-development` rather than inlined.
- [ ] `.upstream-source` marker is present.

This PR is purely agent-skill content sync, no source-code touched (no Rust / TypeScript / schemas / docs-site / locale changes).

https://claude.ai/code/session_0136XaiTt3iF1aoFbj9iP9Vy

---
_Generated by [Claude Code](https://claude.ai/code/session_0136XaiTt3iF1aoFbj9iP9Vy)_