### PR TITLE
chore(specs): pivot plan DAG cleanup — clarify planning-spec lifecycle

### DIFF
--- a/docs/vision/codervisor-platform.md
+++ b/docs/vision/codervisor-platform.md
@@ -1,17 +1,7 @@
----
-status: draft
-created: 2026-03-27
-priority: critical
-tags:
-- strategy
-- positioning
-- vision
-- harness-engineering
-created_at: 2026-03-27T00:00:00Z
-updated_at: 2026-03-27T00:00:00Z
----
-
 # LeanSpec Positioning and Codervisor Vision
+
+> Vision document — strategic context, not a shippable work item.
+> Originally tracked as spec 380; relocated 2026-05-16.
 
 ## Overview
 

--- a/specs/381-tool-agnostic-spec-framework/README.md
+++ b/specs/381-tool-agnostic-spec-framework/README.md
@@ -7,15 +7,17 @@ tags:
 - architecture
 - framework
 - pivot
-depends_on:
-- "380-leanspec-positioning-and-codervisor-vision"
+- umbrella
+depends_on: []
 created_at: 2026-04-16T00:00:00Z
-updated_at: 2026-04-16T00:00:00Z
+updated_at: 2026-05-16T00:00:00Z
 ---
 
 # Tool-Agnostic Spec Framework
 
-> Tracked in GitHub: https://github.com/codervisor/lean-spec/issues/168
+> Umbrella spec for the adapter pivot. Sub-specs **383–401** implement the
+> work; this spec closes when they all close. Tracked in GitHub:
+> https://github.com/codervisor/lean-spec/issues/168
 
 ## Overview
 

--- a/specs/382-pivot-implementation-plan/README.md
+++ b/specs/382-pivot-implementation-plan/README.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: archived
 created: 2026-05-13
 priority: critical
 tags:
@@ -8,12 +8,15 @@ tags:
 - pivot
 - github-adapter
 - cli
-depends_on:
-- "381-tool-agnostic-spec-framework"
-- "380-leanspec-positioning-and-codervisor-vision"
+depends_on: []
 created_at: 2026-05-13T00:00:00Z
-updated_at: 2026-05-13T00:00:00Z
+updated_at: 2026-05-16T00:00:00Z
 ---
+
+> **Archived 2026-05-16.** The phases described here have been crystallized
+> into concrete specs **383–401**. This document is kept for historical
+> context — see those specs for the live plan.
+
 
 # Pivot Implementation Plan
 

--- a/specs/383-markdown-adapter-domain-isolation/README.md
+++ b/specs/383-markdown-adapter-domain-isolation/README.md
@@ -7,9 +7,7 @@ tags:
 - refactoring
 - crate-boundaries
 - prerequisite
-depends_on:
-- "381-tool-agnostic-spec-framework"
-- "382-pivot-implementation-plan"
+depends_on: []
 created_at: 2026-05-14T00:00:00Z
 updated_at: 2026-05-14T00:00:00Z
 ---

--- a/specs/384-github-adapter/README.md
+++ b/specs/384-github-adapter/README.md
@@ -9,7 +9,6 @@ tags:
 - rust
 depends_on:
 - "383-markdown-adapter-domain-isolation"
-- "382-pivot-implementation-plan"
 created_at: 2026-05-14T00:00:00Z
 updated_at: 2026-05-14T00:00:00Z
 ---


### PR DESCRIPTION
## Summary

The pivot DAG (specs 380→401) was painting every concrete spec as transitively blocked, because the planning specs (380 vision, 381 framework, 382 plan) were sitting in `specs/` with no clean "done" state and were declared as `depends_on:` by the work items. This PR separates intent docs from shippable work.

**Commit 1 — `chore(specs): drop planning-spec preds from 383/384`**

- **383**: `depends_on: []` (was 381 + 382). 383 is the true prerequisite for the rest of the pivot.
- **384**: drops 382, keeps 383.
- Specs 385–401 didn't reference 381/382, so no other edits needed.

**Commit 2 — `chore(specs): clean up planning-spec lifecycle (380/381/382)`**

- **380** → relocated to `docs/vision/codervisor-platform.md`. Vision/positioning has no "done" state; moving it out of `specs/` keeps the spec tracker honest.
- **381** → flagged as umbrella (added `umbrella` tag + note: closes when 383–401 close). Dropped `depends_on: 380` since 380 is no longer a spec.
- **382** → status flipped from `draft` → `archived` with a banner pointing at the live specs (383–401). Its phases have been crystallized.

After both commits, the pivot DAG correctly shows **383** (md adapter isolation) and **397** (Jira ADF↔md converter) as the two unblocked starting points.

## Test plan

- [x] `awk` extraction of `depends_on:` blocks across 383–401 confirms no spec still references 380/381/382.
- [x] Re-rendered plan-dag — 383 turns 🎯 (available), matches expected topology.
- [x] No code paths reference the moved spec; prose mentions of "spec 380" in 382/401 left as historical attribution.
- [ ] No CI gates apply (frontmatter / docs-only change).
