### PR TITLE
feat(cli): redesign init as adapter entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`leanspec init --adapter github`** ([issue #263](https://github.com/codervisor/lean-spec/issues/263)) — Initialize a GitHub Issues-backed project from the CLI: detects the GitHub remote, validates `$GITHUB_TOKEN` via `GET /user`, writes `leanspec.adapter.yaml`, and installs an adapter-agnostic `AGENTS.md`. Stubs for `--adapter ado` / `--adapter jira` print a "coming soon" message.
 - **TUI Multi-Project Management** ([spec 372](https://web.lean-spec.dev/specs/372)) — Switch between and manage multiple projects from the TUI
 - **TUI Sidebar Navigation & Tree View** ([spec 371](https://web.lean-spec.dev/specs/371)) — Sidebar with sort/filter controls and hierarchical tree view for specs
 - **TUI Board View Enhancements** — Collapsible board groups with sort indicator, TOC overlay, and scrollbars

--- a/rust/leanspec-cli/Cargo.toml
+++ b/rust/leanspec-cli/Cargo.toml
@@ -19,7 +19,7 @@ clap.workspace = true
 colored.workspace = true
 dialoguer.workspace = true
 indicatif.workspace = true
-leanspec-core = {path = "../leanspec-core", features = ["storage", "git"]}
+leanspec-core = {path = "../leanspec-core", features = ["storage", "git", "github"]}
 notify = "6"
 ratatui.workspace = true
 serde.workspace = true

--- a/rust/leanspec-cli/src/cli_args.rs
+++ b/rust/leanspec-cli/src/cli_args.rs
@@ -227,6 +227,18 @@ pub(crate) enum Commands {
         /// Initialize an example project
         #[arg(long)]
         example: Option<String>,
+
+        /// Backend adapter to initialize: markdown (default), github, ado, jira
+        #[arg(long, default_value = "markdown")]
+        adapter: String,
+
+        /// GitHub adapter: owner/repo override (e.g. "acme/backend")
+        #[arg(long = "owner-repo")]
+        owner_repo: Option<String>,
+
+        /// GitHub adapter: environment variable that holds the token
+        #[arg(long = "token-env", default_value = "GITHUB_TOKEN")]
+        token_env: String,
     },
 
     /// List all specs with optional filtering

--- a/rust/leanspec-cli/src/commands/init.rs
+++ b/rust/leanspec-cli/src/commands/init.rs
@@ -496,6 +496,9 @@ fn run_github_init(options: InitOptions) -> Result<(), Box<dyn Error>> {
         owner.cyan(),
         repo.cyan()
     );
+    // Flush so the "Validating..." line shows up *before* the synchronous HTTP
+    // call rather than appearing only after the call returns.
+    let _ = std::io::Write::flush(&mut std::io::stdout());
     match leanspec_core::adapters::github::validate_token(&token, None) {
         Ok(info) => {
             println!(
@@ -653,8 +656,12 @@ pub(crate) fn parse_owner_repo(spec: &str) -> Option<(String, String)> {
 }
 
 fn read_github_token(token_env: &str) -> Result<String, Box<dyn Error>> {
+    // Trim because shell pipelines like `export GITHUB_TOKEN=$(cat token.txt)`
+    // commonly leave a trailing newline, which would otherwise fail at
+    // `HeaderValue::from_str` deep inside `validate_token` with a confusing
+    // "not a valid HTTP header value" error.
     match std::env::var(token_env) {
-        Ok(t) if !t.trim().is_empty() => Ok(t),
+        Ok(t) if !t.trim().is_empty() => Ok(t.trim().to_string()),
         _ => Err(format!(
             "{} not found in environment.\n\nSet it and re-run, or export it now:\n\n  \
              export {}=ghp_...\n\nSee https://docs.github.com/tokens for how to create one.",

--- a/rust/leanspec-cli/src/commands/init.rs
+++ b/rust/leanspec-cli/src/commands/init.rs
@@ -3,27 +3,62 @@ use dialoguer::{Confirm, Input};
 use serde_json::Value;
 use std::error::Error;
 use std::fs;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use walkdir::WalkDir;
 
 use crate::commands::package_manager::detect_package_manager;
 
 // Embedded AGENTS.md templates
 const AGENTS_MD_TEMPLATE_DETAILED: &str = include_str!("../../templates/AGENTS.md");
+const AGENTS_MD_TEMPLATE_GENERIC: &str = include_str!("../../templates/AGENTS-generic.md");
 
 // Embedded spec template
 const SPEC_TEMPLATE: &str = include_str!("../../templates/spec-template.md");
 
+const VALID_ADAPTERS: &[&str] = &["markdown", "github", "ado", "jira"];
+
 pub struct InitOptions {
     pub yes: bool,
     pub example: Option<String>,
+    pub adapter: String,
+    pub owner_repo: Option<String>,
+    pub token_env: String,
 }
 
 pub fn run(specs_dir: &str, options: InitOptions) -> Result<(), Box<dyn Error>> {
     if let Some(example_name) = options.example.as_deref() {
         return scaffold_example(specs_dir, &options, example_name);
     }
-    run_standard_init(specs_dir, options)
+
+    match options.adapter.as_str() {
+        "markdown" => run_standard_init(specs_dir, options),
+        "github" => run_github_init(options),
+        "ado" => {
+            print_coming_soon("ADO");
+            Ok(())
+        }
+        "jira" => {
+            print_coming_soon("Jira");
+            Ok(())
+        }
+        other => Err(format!(
+            "Unknown adapter '{}'. Valid adapters: {}",
+            other,
+            VALID_ADAPTERS.join(", ")
+        )
+        .into()),
+    }
+}
+
+fn print_coming_soon(label: &str) {
+    println!("{} adapter support coming soon.", label);
+    println!(
+        "Run `{}` or `{}`.",
+        "leanspec init --adapter github".cyan(),
+        "leanspec init --adapter markdown".cyan()
+    );
 }
 
 fn run_standard_init(specs_dir: &str, options: InitOptions) -> Result<(), Box<dyn Error>> {
@@ -137,6 +172,9 @@ fn scaffold_example(
         InitOptions {
             yes: true,
             example: None,
+            adapter: "markdown".to_string(),
+            owner_repo: None,
+            token_env: "GITHUB_TOKEN".to_string(),
         },
     );
     std::env::set_current_dir(&initial_dir)?;
@@ -421,4 +459,337 @@ fn scaffold_agents(root: &Path, project_name: &str) -> Result<(), Box<dyn Error>
         println!("{} AGENTS.md already exists (preserved)", "✓".cyan());
     }
     Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GitHub adapter initialization
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn run_github_init(options: InitOptions) -> Result<(), Box<dyn Error>> {
+    println!();
+    println!("{}", "Initializing GitHub Issues adapter...".bold());
+    println!();
+
+    let cwd = std::env::current_dir()?;
+    let root = find_project_root(&cwd);
+
+    // 1. Detect/prompt for owner/repo.
+    let (owner, repo) = resolve_owner_repo(&root, &options)?;
+    println!(
+        "{} Using repository: {}/{}",
+        "✓".green(),
+        owner.cyan(),
+        repo.cyan()
+    );
+
+    // 2. Read and validate the token.
+    let token = read_github_token(&options.token_env)?;
+    println!(
+        "{} Found {} ({} chars)",
+        "✓".green(),
+        options.token_env.cyan(),
+        token.len()
+    );
+
+    print!(
+        "  Validating token against {}/{}... ",
+        owner.cyan(),
+        repo.cyan()
+    );
+    match leanspec_core::adapters::github::validate_token(&token, None) {
+        Ok(info) => {
+            println!(
+                "{} authenticated as {}",
+                "✓".green(),
+                format!("@{}", info.user_login).cyan()
+            );
+            if !info.scopes.is_empty() && !info.has_repo_scope() {
+                println!(
+                    "{} Token lacks 'repo' scope; some operations may be \
+                     read-only. Scopes: {}",
+                    "⚠".yellow(),
+                    info.scopes.join(", ")
+                );
+            }
+        }
+        Err(err) => {
+            return Err(format!(
+                "GitHub token validation failed: {}\n\n\
+                 Set a valid token and re-run:\n\n  \
+                 export {}=ghp_...\n\n\
+                 See https://docs.github.com/tokens for how to create one.",
+                err, options.token_env
+            )
+            .into());
+        }
+    }
+
+    // 3. Write `leanspec.adapter.yaml` to the project root.
+    write_github_adapter_yaml(&root, &owner, &repo, &options.token_env)?;
+
+    // 4. Write the adapter-agnostic AGENTS.md.
+    let project_name = root
+        .file_name()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or("project");
+    scaffold_generic_agents(&root, project_name)?;
+
+    println!();
+    println!("{}", "Done.".green().bold());
+    println!(
+        "Run `{}` to see available operations.",
+        "leanspec capabilities".cyan()
+    );
+
+    Ok(())
+}
+
+fn resolve_owner_repo(
+    root: &Path,
+    options: &InitOptions,
+) -> Result<(String, String), Box<dyn Error>> {
+    // Explicit CLI override wins.
+    if let Some(spec) = options.owner_repo.as_deref() {
+        return parse_owner_repo(spec).ok_or_else(|| {
+            format!("--owner-repo must be in 'owner/repo' format, got '{spec}'").into()
+        });
+    }
+
+    let detected = detect_github_remote(root);
+    let interactive = !options.yes && std::io::stdin().is_terminal();
+
+    match (detected.clone(), interactive) {
+        (Some((owner, repo)), true) => {
+            println!(
+                "{} Detected remote: github.com/{}/{}",
+                "✓".green(),
+                owner,
+                repo
+            );
+            let default = format!("{}/{}", owner, repo);
+            let input: String = Input::new()
+                .with_prompt("Owner/repo (Enter to accept)")
+                .default(default.clone())
+                .allow_empty(true)
+                .interact_text()?;
+            let trimmed = input.trim();
+            if trimmed.is_empty() {
+                Ok((owner, repo))
+            } else {
+                parse_owner_repo(trimmed)
+                    .ok_or_else(|| format!("expected 'owner/repo' format, got '{trimmed}'").into())
+            }
+        }
+        (Some(pair), false) => Ok(pair),
+        (None, true) => {
+            println!("{} No GitHub remote detected.", "⚠".yellow());
+            let input: String = Input::new()
+                .with_prompt("Owner/repo (e.g. acme/backend)")
+                .interact_text()?;
+            parse_owner_repo(input.trim()).ok_or_else(|| {
+                format!("expected 'owner/repo' format, got '{}'", input.trim()).into()
+            })
+        }
+        (None, false) => Err("Could not detect a GitHub remote and no \
+            --owner-repo was provided. Pass --owner-repo owner/repo or run \
+            inside a git repository with a github.com remote."
+            .into()),
+    }
+}
+
+/// Parse `git remote get-url origin` and extract the (owner, repo) pair.
+/// Supports HTTPS (`https://github.com/owner/repo.git`) and SSH
+/// (`git@github.com:owner/repo.git`) URLs.
+pub(crate) fn detect_github_remote(root: &Path) -> Option<(String, String)> {
+    let output = Command::new("git")
+        .args(["-C", &root.to_string_lossy(), "remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    parse_github_url(&url)
+}
+
+/// Best-effort parser for GitHub remote URLs. Returns None on non-GitHub
+/// hosts so the caller can fall back to prompting.
+pub(crate) fn parse_github_url(url: &str) -> Option<(String, String)> {
+    let url = url.trim();
+
+    // SSH: git@github.com:owner/repo(.git)?
+    if let Some(rest) = url.strip_prefix("git@github.com:") {
+        return parse_owner_repo(rest.trim_end_matches(".git"));
+    }
+    if let Some(rest) = url.strip_prefix("ssh://git@github.com/") {
+        return parse_owner_repo(rest.trim_end_matches(".git"));
+    }
+
+    // HTTPS: https://github.com/owner/repo(.git)?
+    for prefix in [
+        "https://github.com/",
+        "http://github.com/",
+        "https://www.github.com/",
+    ] {
+        if let Some(rest) = url.strip_prefix(prefix) {
+            return parse_owner_repo(rest.trim_end_matches('/').trim_end_matches(".git"));
+        }
+    }
+
+    None
+}
+
+pub(crate) fn parse_owner_repo(spec: &str) -> Option<(String, String)> {
+    let spec = spec.trim();
+    let (owner, repo) = spec.split_once('/')?;
+    let owner = owner.trim();
+    // Reject anything beyond a single owner/repo segment.
+    let repo = repo.trim().trim_end_matches('/');
+    if owner.is_empty() || repo.is_empty() || repo.contains('/') {
+        return None;
+    }
+    Some((owner.to_string(), repo.to_string()))
+}
+
+fn read_github_token(token_env: &str) -> Result<String, Box<dyn Error>> {
+    match std::env::var(token_env) {
+        Ok(t) if !t.trim().is_empty() => Ok(t),
+        _ => Err(format!(
+            "{} not found in environment.\n\nSet it and re-run, or export it now:\n\n  \
+             export {}=ghp_...\n\nSee https://docs.github.com/tokens for how to create one.",
+            token_env, token_env
+        )
+        .into()),
+    }
+}
+
+fn write_github_adapter_yaml(
+    root: &Path,
+    owner: &str,
+    repo: &str,
+    token_env: &str,
+) -> Result<(), Box<dyn Error>> {
+    let path = root.join("leanspec.adapter.yaml");
+    if path.exists() {
+        println!(
+            "{} {} already exists (preserved)",
+            "✓".cyan(),
+            path.display()
+        );
+        return Ok(());
+    }
+
+    let mut body = String::from("# Written by leanspec init --adapter github\n");
+    body.push_str("adapter: github\n");
+    body.push_str("settings:\n");
+    body.push_str(&format!("  owner: {}\n", owner));
+    body.push_str(&format!("  repo: {}\n", repo));
+    if token_env == "GITHUB_TOKEN" {
+        body.push_str(
+            "  # token_env defaults to GITHUB_TOKEN; override if needed:\n  \
+             # token_env: MY_CUSTOM_TOKEN_VAR\n",
+        );
+    } else {
+        body.push_str(&format!("  token_env: {}\n", token_env));
+    }
+
+    fs::write(&path, body)?;
+    println!("{} Wrote {}", "✓".green(), path.display());
+    Ok(())
+}
+
+fn scaffold_generic_agents(root: &Path, project_name: &str) -> Result<(), Box<dyn Error>> {
+    let agents_path = root.join("AGENTS.md");
+    if agents_path.exists() {
+        println!("{} AGENTS.md already exists (preserved)", "✓".cyan());
+        return Ok(());
+    }
+    let content = AGENTS_MD_TEMPLATE_GENERIC.replace("{project_name}", project_name);
+    fs::write(&agents_path, content)?;
+    println!("{} Created AGENTS.md", "✓".green());
+    Ok(())
+}
+
+/// Walk up from `start` looking for a `.git` directory; fall back to `start`
+/// if none is found. Matches `AdapterRegistry::from_project()` semantics.
+fn find_project_root(start: &Path) -> PathBuf {
+    let mut current = Some(start);
+    while let Some(dir) = current {
+        if dir.join(".git").exists() {
+            return dir.to_path_buf();
+        }
+        current = dir.parent();
+    }
+    start.to_path_buf()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_owner_repo_accepts_simple_pair() {
+        assert_eq!(
+            parse_owner_repo("acme/backend"),
+            Some(("acme".into(), "backend".into()))
+        );
+    }
+
+    #[test]
+    fn parse_owner_repo_strips_trailing_slash_and_whitespace() {
+        assert_eq!(
+            parse_owner_repo("  acme/backend/  "),
+            Some(("acme".into(), "backend".into()))
+        );
+    }
+
+    #[test]
+    fn parse_owner_repo_rejects_extra_segments() {
+        assert_eq!(parse_owner_repo("acme/backend/extra"), None);
+    }
+
+    #[test]
+    fn parse_owner_repo_rejects_missing_repo() {
+        assert_eq!(parse_owner_repo("acme/"), None);
+        assert_eq!(parse_owner_repo("/backend"), None);
+        assert_eq!(parse_owner_repo("acme"), None);
+    }
+
+    #[test]
+    fn parse_github_url_handles_https() {
+        assert_eq!(
+            parse_github_url("https://github.com/acme/backend.git"),
+            Some(("acme".into(), "backend".into()))
+        );
+        assert_eq!(
+            parse_github_url("https://github.com/acme/backend"),
+            Some(("acme".into(), "backend".into()))
+        );
+        assert_eq!(
+            parse_github_url("https://github.com/acme/backend/"),
+            Some(("acme".into(), "backend".into()))
+        );
+    }
+
+    #[test]
+    fn parse_github_url_handles_ssh() {
+        assert_eq!(
+            parse_github_url("git@github.com:acme/backend.git"),
+            Some(("acme".into(), "backend".into()))
+        );
+        assert_eq!(
+            parse_github_url("git@github.com:acme/backend"),
+            Some(("acme".into(), "backend".into()))
+        );
+    }
+
+    #[test]
+    fn parse_github_url_rejects_non_github_hosts() {
+        assert_eq!(
+            parse_github_url("https://gitlab.com/acme/backend.git"),
+            None
+        );
+        assert_eq!(parse_github_url("git@bitbucket.org:acme/backend.git"), None);
+    }
 }

--- a/rust/leanspec-cli/src/main.rs
+++ b/rust/leanspec-cli/src/main.rs
@@ -116,9 +116,22 @@ fn main() -> ExitCode {
             commands::git_repo::run(cmd, &cli.output)
         }
         Commands::Gantt { status } => commands::gantt::run(&specs_dir, status, &cli.output),
-        Commands::Init { yes, example } => {
-            commands::init::run(&specs_dir, commands::init::InitOptions { yes, example })
-        }
+        Commands::Init {
+            yes,
+            example,
+            adapter,
+            owner_repo,
+            token_env,
+        } => commands::init::run(
+            &specs_dir,
+            commands::init::InitOptions {
+                yes,
+                example,
+                adapter,
+                owner_repo,
+                token_env,
+            },
+        ),
         Commands::List {
             status,
             tag,

--- a/rust/leanspec-cli/templates/AGENTS-generic.md
+++ b/rust/leanspec-cli/templates/AGENTS-generic.md
@@ -1,0 +1,14 @@
+# {project_name} — Agent Guide
+
+This project uses LeanSpec for spec-driven development.
+
+## Working with specs
+
+- List: `leanspec list`
+- View: `leanspec view <spec>`
+- Create: `leanspec create "Title"`
+- Update: `leanspec update <spec> --status in-progress`
+- Search: `leanspec search "keyword"`
+
+Run `leanspec capabilities` to see all available operations and fields for
+the active adapter.

--- a/rust/leanspec-core/src/adapters/github/mod.rs
+++ b/rust/leanspec-core/src/adapters/github/mod.rs
@@ -710,6 +710,114 @@ impl Adapter for GitHubAdapter {
     }
 }
 
+/// Outcome of validating a GitHub token against `GET /user`.
+///
+/// Used by `leanspec init --adapter github` to fail fast when the configured
+/// token is invalid, and to warn (but proceed) when the token lacks the `repo`
+/// OAuth scope.
+#[derive(Debug, Clone)]
+pub struct TokenValidation {
+    /// Authenticated user login (the GitHub username the token belongs to).
+    pub user_login: String,
+    /// OAuth scopes parsed from the `X-OAuth-Scopes` response header. Fine-
+    /// grained personal access tokens return an empty list — callers should
+    /// treat absence of scopes as "unknown" rather than "no permissions".
+    pub scopes: Vec<String>,
+}
+
+impl TokenValidation {
+    /// True if the token's `X-OAuth-Scopes` header contains `repo` (or one of
+    /// its narrower subscopes). Fine-grained tokens don't expose scopes via
+    /// this header, so an empty `scopes` list returns `false` here even though
+    /// the token may still have the necessary permissions.
+    pub fn has_repo_scope(&self) -> bool {
+        self.scopes.iter().any(|s| {
+            matches!(
+                s.as_str(),
+                "repo" | "public_repo" | "repo:status" | "repo_deployment"
+            )
+        })
+    }
+}
+
+/// Validate a GitHub bearer token by calling `GET /user`.
+///
+/// `base_url` defaults to `https://api.github.com` and exists so tests can
+/// route traffic at a mock server. Returns the authenticated user and the
+/// OAuth scopes advertised by the server.
+pub fn validate_token(
+    token: &str,
+    base_url: Option<&str>,
+) -> Result<TokenValidation, AdapterError> {
+    let base = base_url
+        .unwrap_or("https://api.github.com")
+        .trim_end_matches('/');
+    let url = format!("{base}/user");
+
+    // Sanity check the token shape early so we fail with a clear AuthError
+    // instead of a confusing reqwest header error.
+    HeaderValue::from_str(&format!("Bearer {token}")).map_err(|e| AdapterError::AuthError {
+        adapter: ADAPTER_NAME.into(),
+        reason: format!("token is not a valid HTTP header value: {e}"),
+    })?;
+
+    let client = Client::builder()
+        .user_agent("leanspec-github-adapter")
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|e| AdapterError::BackendError {
+            adapter: ADAPTER_NAME.into(),
+            reason: format!("failed to construct HTTP client: {e}"),
+        })?;
+
+    let resp = client
+        .get(&url)
+        .header(AUTHORIZATION, format!("Bearer {token}"))
+        .header(ACCEPT, "application/vnd.github+json")
+        .header(USER_AGENT, "leanspec-github-adapter")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .send()
+        .map_err(|e| AdapterError::BackendError {
+            adapter: ADAPTER_NAME.into(),
+            reason: format!("network: {e}"),
+        })?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let headers = resp.headers().clone();
+        let body = resp.text().unwrap_or_default();
+        return Err(map_error(status, &headers, &body));
+    }
+
+    let scopes = resp
+        .headers()
+        .get("x-oauth-scopes")
+        .and_then(|h| h.to_str().ok())
+        .map(|s| {
+            s.split(',')
+                .map(|scope| scope.trim().to_string())
+                .filter(|scope| !scope.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let body: Value = resp.json().map_err(|e| AdapterError::ParseError {
+        path: "github /user response".into(),
+        reason: e.to_string(),
+    })?;
+
+    let user_login = body
+        .get("login")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AdapterError::ParseError {
+            path: "github /user response".into(),
+            reason: "missing 'login' field".into(),
+        })?
+        .to_string();
+
+    Ok(TokenValidation { user_login, scopes })
+}
+
 /// Project a GitHub issue JSON payload onto a [`SpecDoc`].
 pub(crate) fn issue_to_doc(issue: &Value) -> SpecDoc {
     let number = issue
@@ -1138,6 +1246,74 @@ mod tests {
             Ok(_) => panic!("should reject invalid token"),
             Err(AdapterError::AuthError { .. }) => {}
             Err(other) => panic!("expected AuthError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_token_returns_user_and_scopes() {
+        let mut server = mockito::Server::new();
+        let _m = server
+            .mock("GET", "/user")
+            .match_header("authorization", "Bearer good-token")
+            .with_status(200)
+            .with_header("x-oauth-scopes", "repo, read:org, workflow")
+            .with_body(r#"{"login":"alice","id":42}"#)
+            .create();
+
+        let info = validate_token("good-token", Some(&server.url())).unwrap();
+        assert_eq!(info.user_login, "alice");
+        assert_eq!(info.scopes, vec!["repo", "read:org", "workflow"]);
+        assert!(info.has_repo_scope());
+    }
+
+    #[test]
+    fn validate_token_no_repo_scope() {
+        let mut server = mockito::Server::new();
+        let _m = server
+            .mock("GET", "/user")
+            .with_status(200)
+            .with_header("x-oauth-scopes", "read:user")
+            .with_body(r#"{"login":"bob"}"#)
+            .create();
+
+        let info = validate_token("limited-token", Some(&server.url())).unwrap();
+        assert!(!info.has_repo_scope());
+    }
+
+    #[test]
+    fn validate_token_fine_grained_no_scopes_header() {
+        let mut server = mockito::Server::new();
+        let _m = server
+            .mock("GET", "/user")
+            .with_status(200)
+            .with_body(r#"{"login":"carol"}"#)
+            .create();
+
+        let info = validate_token("fine-grained", Some(&server.url())).unwrap();
+        assert!(info.scopes.is_empty());
+        assert!(!info.has_repo_scope());
+    }
+
+    #[test]
+    fn validate_token_401_is_auth_error() {
+        let mut server = mockito::Server::new();
+        let _m = server
+            .mock("GET", "/user")
+            .with_status(401)
+            .with_body(r#"{"message":"Bad credentials"}"#)
+            .create();
+
+        match validate_token("bad-token", Some(&server.url())) {
+            Err(AdapterError::AuthError { .. }) => {}
+            other => panic!("expected AuthError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_token_rejects_invalid_header_value() {
+        match validate_token("bad\ntoken", Some("http://localhost")) {
+            Err(AdapterError::AuthError { .. }) => {}
+            other => panic!("expected AuthError, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
Closes #263.

## Summary

`leanspec init` becomes the entry point for every adapter:

```bash
leanspec init                    # markdown (unchanged)
leanspec init --adapter github   # GitHub Issues backend
leanspec init --adapter ado      # stub — "coming soon"
leanspec init --adapter jira     # stub — "coming soon"
```

A user can now go from zero to a GitHub-backed project using only
`leanspec init --adapter github`.

### What landed

- **`--adapter` flag** on `Commands::Init`, default `markdown` so the existing
  markdown flow is byte-for-byte unchanged.
- **GitHub init flow** (`commands/init.rs::run_github_init`):
  - Detects the remote from `git remote get-url origin` (HTTPS + SSH).
  - In a TTY, prompts to confirm or override `owner/repo` (default is the
    detected pair). Non-interactive runs use detection / `--owner-repo` and
    error out clearly if neither is available.
  - Reads `$GITHUB_TOKEN` (env var name is overridable via `--token-env`).
  - Validates the token via the new `leanspec_core::adapters::github::validate_token`
    helper that calls `GET /user`, surfaces 401 as a clear `AuthError`, and
    warns (but proceeds) when the OAuth `repo` scope is missing.
  - Writes `leanspec.adapter.yaml` to the project root (the `.git/` ancestor,
    matching `AdapterRegistry::from_project()`), never committing the token.
  - Installs a new adapter-agnostic `AGENTS.md` template
    (`templates/AGENTS-generic.md`) — no markdown-specific guidance.
  - **Does not** scaffold a `specs/` directory.
- **ADO / Jira stubs** print `"<adapter> adapter support coming soon."` and
  exit 0.
- **Unknown adapter** errors with the valid list and exits non-zero.
- **CLI now builds with the `github` feature** on `leanspec-core` so
  `leanspec capabilities` works against a GitHub project right after init.

### `validate_token` API

```rust
pub fn validate_token(
    token: &str,
    base_url: Option<&str>,
) -> Result<TokenValidation, AdapterError>;

pub struct TokenValidation {
    pub user_login: String,
    pub scopes: Vec<String>,
}

impl TokenValidation {
    pub fn has_repo_scope(&self) -> bool { … }
}
```

Lives behind the existing `github` feature alongside `GitHubAdapter`.

## Test plan

- [x] `cargo test -p leanspec-core --features github` — 244 passed, including:
  - `validate_token_returns_user_and_scopes`
  - `validate_token_no_repo_scope`
  - `validate_token_fine_grained_no_scopes_header`
  - `validate_token_401_is_auth_error`
  - `validate_token_rejects_invalid_header_value`
- [x] `cargo clippy -p leanspec-core --features github` clean
- [x] `cargo fmt --check` clean
- [x] Pure-function unit tests for `parse_owner_repo` and `parse_github_url`
      covering HTTPS, SSH, trailing slashes, extra segments, and non-GitHub
      hosts.
- [ ] `cargo build -p leanspec-cli` — **blocked**: 81 pre-existing import
      errors in unrelated CLI modules (`board.rs`, `create.rs`, …) caused by
      the markdown-isolation refactor in #285 / spec #258 (still `planned`).
      All errors in this PR's `init.rs` are resolved; the binary will build
      once the remaining CLI commands are migrated to
      `leanspec_core::adapters::markdown::*`.

## Notes for review

- `leanspec.adapter.yaml` is written safely — token is read from the env
  var configured by `token_env` (defaults to `GITHUB_TOKEN`), never inlined.
- The existing markdown `AGENTS.md` template is preserved for
  `--adapter markdown`; the new generic template only applies to non-markdown
  adapters.
- Token-scope warning is best-effort: fine-grained PATs don't expose
  `X-OAuth-Scopes`, so an empty scope list is treated as "unknown" rather
  than "no permissions" — we proceed without warning in that case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKTa1ARD63QSMKDGppxssK)_