### PR TITLE
feat(core): add adapter compliance test harness

### DIFF
--- a/rust/leanspec-core/Cargo.toml
+++ b/rust/leanspec-core/Cargo.toml
@@ -46,6 +46,9 @@ github = ["dep:reqwest", "reqwest/blocking", "reqwest/json", "reqwest/default-tl
 # Requires `GITHUB_TOKEN`, `TEST_GITHUB_OWNER`, `TEST_GITHUB_REPO` env vars.
 github-integration-tests = ["github"]
 storage = ["tokio", "dirs", "uuid"]
+# Expose the adapter compliance test harness for use by out-of-tree
+# adapter implementations. Always available within this crate's own tests.
+test-utils = []
 
 [dev-dependencies]
 mockito = "1.5"

--- a/rust/leanspec-core/src/adapters/github/mod.rs
+++ b/rust/leanspec-core/src/adapters/github/mod.rs
@@ -995,6 +995,21 @@ mod tests {
     }
 
     #[test]
+    fn passes_schema_compliance_check() {
+        use crate::adapters::test_harness::{check_schema_consistency, ComplianceOptions};
+        let s = mockito::Server::new();
+        let a = adapter(&s);
+        let opts = ComplianceOptions {
+            status_active: "open".into(),
+            status_alt: "closed".into(),
+            delete_is_archive: true,
+            supports_links: false,
+            ..ComplianceOptions::default()
+        };
+        check_schema_consistency(&a, &opts);
+    }
+
+    #[test]
     fn capabilities_match_spec() {
         let s = mockito::Server::new();
         let a = adapter(&s);
@@ -1655,11 +1670,31 @@ mod tests {
 #[cfg(all(test, feature = "github-integration-tests"))]
 mod integration {
     use super::*;
+    use crate::adapters::test_harness::{run_compliance_suite, ComplianceOptions};
 
     fn live_adapter() -> Option<GitHubAdapter> {
         let owner = std::env::var("TEST_GITHUB_OWNER").ok()?;
         let repo = std::env::var("TEST_GITHUB_REPO").ok()?;
         GitHubAdapter::new(owner, repo, "GITHUB_TOKEN").ok()
+    }
+
+    fn github_compliance_options() -> ComplianceOptions {
+        ComplianceOptions {
+            status_active: "open".into(),
+            status_alt: "closed".into(),
+            delete_is_archive: true,
+            supports_links: false,
+            ..ComplianceOptions::default()
+        }
+    }
+
+    #[test]
+    #[ignore = "hits real GitHub API; requires GITHUB_TOKEN + TEST_GITHUB_OWNER + TEST_GITHUB_REPO"]
+    fn integration_compliance_suite() {
+        let Some(adapter) = live_adapter() else {
+            return;
+        };
+        run_compliance_suite(&adapter, &github_compliance_options());
     }
 
     #[test]

--- a/rust/leanspec-core/src/adapters/markdown/mod.rs
+++ b/rust/leanspec-core/src/adapters/markdown/mod.rs
@@ -670,7 +670,10 @@ impl Adapter for MarkdownAdapter {
 
         writer
             .update_metadata(id, meta_update)
-            .map_err(|e| AdapterError::IoError(std::io::Error::other(e.to_string())))?;
+            .map_err(|e| match e {
+                writer::WriteError::NotFound(p) => AdapterError::NotFound(p),
+                other => AdapterError::IoError(std::io::Error::other(other.to_string())),
+            })?;
 
         // Second pass: title, content body, and extended frontmatter fields
         // (reviewer, issue, pr, epic, breaking, due) rewrite the file directly.
@@ -769,7 +772,10 @@ impl Adapter for MarkdownAdapter {
     fn delete(&self, id: &str) -> Result<(), AdapterError> {
         SpecArchiver::new(&self.specs_dir)
             .archive(id)
-            .map_err(|e| AdapterError::IoError(std::io::Error::other(e.to_string())))
+            .map_err(|e| match e {
+                archiver::ArchiveError::NotFound(p) => AdapterError::NotFound(p),
+                other => AdapterError::IoError(std::io::Error::other(other.to_string())),
+            })
     }
 
     fn search(&self, query: &str, opts: &SearchOptions) -> Result<Vec<SearchHit>, AdapterError> {
@@ -1210,4 +1216,34 @@ mod tests {
             .unwrap();
         assert!(hits.iter().any(|h| h.id == "001-auth"));
     }
+}
+
+#[cfg(test)]
+mod compliance {
+    use super::*;
+    use crate::adapter_compliance_tests;
+    use crate::adapters::test_harness::ComplianceOptions;
+    use tempfile::TempDir;
+
+    fn make_markdown_adapter() -> (MarkdownAdapter, TempDir) {
+        let dir = TempDir::new().expect("tempdir");
+        let specs = dir.path().join("specs");
+        std::fs::create_dir_all(&specs).expect("create specs dir");
+        let adapter = MarkdownAdapter::new(specs);
+        (adapter, dir)
+    }
+
+    fn markdown_options() -> ComplianceOptions {
+        ComplianceOptions {
+            status_active: "planned".into(),
+            status_alt: "in-progress".into(),
+            delete_is_archive: true,
+            supports_links: true,
+            link_type: link::DEPENDS_ON.into(),
+            link_target: "001-foundation".into(),
+            ..ComplianceOptions::default()
+        }
+    }
+
+    adapter_compliance_tests!(make_markdown_adapter, markdown_options());
 }

--- a/rust/leanspec-core/src/adapters/mod.rs
+++ b/rust/leanspec-core/src/adapters/mod.rs
@@ -20,6 +20,9 @@ pub mod jira;
 pub mod markdown;
 pub mod registry;
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_harness;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/rust/leanspec-core/src/adapters/test_harness.rs
+++ b/rust/leanspec-core/src/adapters/test_harness.rs
@@ -101,7 +101,7 @@ fn make_create_request(title: &str, body: &str, opts: &ComplianceOptions) -> Cre
 }
 
 /// Schema-level invariants. Pure — runs no mutations.
-pub fn check_schema_consistency<A: Adapter + ?Sized>(adapter: &A, _opts: &ComplianceOptions) {
+pub fn check_schema_consistency<A: Adapter + ?Sized>(adapter: &A, opts: &ComplianceOptions) {
     let schema = adapter.schema();
     assert!(!schema.fields.is_empty(), "schema.fields must not be empty");
 
@@ -139,6 +139,27 @@ pub fn check_schema_consistency<A: Adapter + ?Sized>(adapter: &A, _opts: &Compli
         "schema must declare a field with semantic 'status'"
     );
 
+    // Cross-check ComplianceOptions against the schema so misconfigured
+    // adapters fail fast here with a clear message rather than deep inside
+    // a CRUD or list test where the diagnostic is muddier.
+    assert!(
+        schema.field(&opts.status_key).is_some(),
+        "ComplianceOptions.status_key '{}' must exist in the schema",
+        opts.status_key
+    );
+    assert!(
+        schema.field(&opts.content_key).is_some(),
+        "ComplianceOptions.content_key '{}' must exist in the schema",
+        opts.content_key
+    );
+    if opts.supports_links {
+        assert!(
+            schema.link_types.iter().any(|lt| lt.key == opts.link_type),
+            "ComplianceOptions.link_type '{}' must be declared in schema.link_types",
+            opts.link_type
+        );
+    }
+
     let caps = adapter.capabilities();
     assert!(!caps.name.is_empty(), "capabilities.name must not be empty");
     assert_eq!(
@@ -169,16 +190,20 @@ pub fn check_crud_roundtrip<A: Adapter + ?Sized>(adapter: &A, opts: &ComplianceO
         fetched.title, title,
         "get() must return the same title that was created"
     );
-    if let Some(content) = fetched
+    let content = fetched
         .fields
         .get(&opts.content_key)
         .and_then(|v| v.as_str())
-    {
-        assert!(
-            content.contains("Body for CRUD test"),
-            "body content must round-trip on get() — got {content:?}"
-        );
-    }
+        .unwrap_or_else(|| {
+            panic!(
+                "content field '{}' must be present on get() after create() set it",
+                opts.content_key
+            )
+        });
+    assert!(
+        content.contains("Body for CRUD test"),
+        "body content must round-trip on get() — got {content:?}"
+    );
 
     // Title update.
     let new_title = format!("{title} (renamed)");
@@ -294,9 +319,15 @@ pub fn check_list_filter<A: Adapter + ?Sized>(adapter: &A, opts: &ComplianceOpti
         "free-text filter on a unique marker must match the created item"
     );
 
-    // Archived items must be excluded from the default list.
+    // Cleanup: always delete the created item so persistent backends (e.g.
+    // the real GitHub API in integration tests) don't accumulate fixtures
+    // across compliance runs. The post-delete archive assertion is gated on
+    // `delete_is_archive` because only archive adapters keep the item
+    // around for the "excluded from default list" semantics.
+    adapter
+        .delete(&created.id)
+        .expect("cleanup delete must succeed");
     if opts.delete_is_archive {
-        adapter.delete(&created.id).expect("delete must succeed");
         let listed_after = adapter
             .list(&ListFilter::default())
             .expect("list after delete must succeed");
@@ -333,6 +364,11 @@ pub fn check_search<A: Adapter + ?Sized>(adapter: &A, opts: &ComplianceOptions) 
         no_hits.is_empty(),
         "search for a nonexistent term must return an empty vec — got {no_hits:?}"
     );
+
+    // Cleanup so persistent backends don't accumulate test fixtures.
+    adapter
+        .delete(&created.id)
+        .expect("cleanup delete must succeed");
 }
 
 /// Link round-trip — skipped silently when the adapter doesn't model links.
@@ -358,6 +394,11 @@ pub fn check_links<A: Adapter + ?Sized>(adapter: &A, opts: &ComplianceOptions) {
             .any(|l| l.link_type == opts.link_type && l.target_id == opts.link_target),
         "the created link must round-trip on get_links() — got {links:?}"
     );
+
+    // Cleanup so persistent backends don't accumulate test fixtures.
+    adapter
+        .delete(&created.id)
+        .expect("cleanup delete must succeed");
 }
 
 /// `get` / `update` / `delete` on a nonexistent id all return `NotFound`.
@@ -430,37 +471,43 @@ macro_rules! adapter_compliance_tests {
         #[test]
         fn compliance_schema_consistency() {
             let (adapter, _fixture) = ($factory)();
-            $crate::adapters::test_harness::check_schema_consistency(&adapter, &$opts);
+            let opts = $opts;
+            $crate::adapters::test_harness::check_schema_consistency(&adapter, &opts);
         }
 
         #[test]
         fn compliance_crud_roundtrip() {
             let (adapter, _fixture) = ($factory)();
-            $crate::adapters::test_harness::check_crud_roundtrip(&adapter, &$opts);
+            let opts = $opts;
+            $crate::adapters::test_harness::check_crud_roundtrip(&adapter, &opts);
         }
 
         #[test]
         fn compliance_list_filter() {
             let (adapter, _fixture) = ($factory)();
-            $crate::adapters::test_harness::check_list_filter(&adapter, &$opts);
+            let opts = $opts;
+            $crate::adapters::test_harness::check_list_filter(&adapter, &opts);
         }
 
         #[test]
         fn compliance_search() {
             let (adapter, _fixture) = ($factory)();
-            $crate::adapters::test_harness::check_search(&adapter, &$opts);
+            let opts = $opts;
+            $crate::adapters::test_harness::check_search(&adapter, &opts);
         }
 
         #[test]
         fn compliance_links() {
             let (adapter, _fixture) = ($factory)();
-            $crate::adapters::test_harness::check_links(&adapter, &$opts);
+            let opts = $opts;
+            $crate::adapters::test_harness::check_links(&adapter, &opts);
         }
 
         #[test]
         fn compliance_error_cases() {
             let (adapter, _fixture) = ($factory)();
-            $crate::adapters::test_harness::check_error_cases(&adapter, &$opts);
+            let opts = $opts;
+            $crate::adapters::test_harness::check_error_cases(&adapter, &opts);
         }
     };
 }

--- a/rust/leanspec-core/src/adapters/test_harness.rs
+++ b/rust/leanspec-core/src/adapters/test_harness.rs
@@ -1,0 +1,466 @@
+//! Reusable compliance test suite that every [`Adapter`](super::Adapter)
+//! implementation must satisfy.
+//!
+//! The harness exercises the behavioural contract: schema consistency, CRUD
+//! round-trip, list / filter, search, optional links, and the standard error
+//! cases. An adapter that returns wrong data on `get()` after `create()` —
+//! or that maps `delete(nonexistent)` to the wrong error variant — fails
+//! the relevant compliance test, so backends stay in lock-step over time.
+//!
+//! ## Usage
+//!
+//! The macro form generates one `#[test]` per category, so each case shows
+//! up individually in `cargo test` output:
+//!
+//! ```rust,ignore
+//! use leanspec_core::adapter_compliance_tests;
+//! use leanspec_core::adapters::test_harness::ComplianceOptions;
+//!
+//! fn make_adapter() -> (MyAdapter, MyFixture) {
+//!     // …
+//! }
+//!
+//! adapter_compliance_tests!(make_adapter, ComplianceOptions::default());
+//! ```
+//!
+//! Or call [`run_compliance_suite`] directly to run every case sequentially
+//! against a single adapter instance.
+//!
+//! ## Skippable contract points
+//!
+//! Not every adapter supports every operation the same way. Use
+//! [`ComplianceOptions`] to opt out of contract points that can't hold for a
+//! given backend (e.g. hard-delete vs soft archive, link support).
+
+use std::collections::HashMap;
+
+use super::{Adapter, AdapterError, ListFilter, SearchOptions};
+use crate::model::{semantic, CreateRequest, FieldKind, FieldValue, ItemLink, UpdateRequest};
+
+/// Configuration for the compliance suite — lets an adapter declare which
+/// contract points apply and which valid status values to use.
+#[derive(Debug, Clone)]
+pub struct ComplianceOptions {
+    /// Field key for the status field. Defaults to `"status"`.
+    pub status_key: String,
+
+    /// A valid `status` value used when creating items in tests.
+    pub status_active: String,
+
+    /// A second valid `status` value used to verify status updates.
+    pub status_alt: String,
+
+    /// Field key for the long-form body. Defaults to `"content"`.
+    pub content_key: String,
+
+    /// `true` when `delete()` archives rather than hard-deletes. The harness
+    /// then asserts that `get()` still succeeds after delete but the item is
+    /// excluded from `list()` unless `include_archived: true` is set.
+    pub delete_is_archive: bool,
+
+    /// Set to `true` to enable the link round-trip test.
+    pub supports_links: bool,
+
+    /// Link type used in the link round-trip (e.g. `"depends_on"`).
+    pub link_type: String,
+
+    /// Target id used in the link round-trip. Adapters that don't validate
+    /// link targets can leave this as the default stub id.
+    pub link_target: String,
+}
+
+impl Default for ComplianceOptions {
+    fn default() -> Self {
+        Self {
+            status_key: "status".into(),
+            status_active: "planned".into(),
+            status_alt: "in-progress".into(),
+            content_key: "content".into(),
+            delete_is_archive: true,
+            supports_links: false,
+            link_type: "depends_on".into(),
+            link_target: "001-foundation".into(),
+        }
+    }
+}
+
+fn make_create_request(title: &str, body: &str, opts: &ComplianceOptions) -> CreateRequest {
+    let mut fields = HashMap::new();
+    fields.insert(
+        opts.status_key.clone(),
+        FieldValue::String(opts.status_active.clone()),
+    );
+    fields.insert(opts.content_key.clone(), FieldValue::String(body.into()));
+    CreateRequest {
+        slug: None,
+        title: title.into(),
+        schema_id: None,
+        fields,
+        links: vec![],
+    }
+}
+
+/// Schema-level invariants. Pure — runs no mutations.
+pub fn check_schema_consistency<A: Adapter + ?Sized>(adapter: &A, _opts: &ComplianceOptions) {
+    let schema = adapter.schema();
+    assert!(!schema.fields.is_empty(), "schema.fields must not be empty");
+
+    for field in &schema.fields {
+        assert!(
+            !field.key.is_empty(),
+            "every field must have a non-empty key (offender: {field:?})"
+        );
+        assert!(
+            !field.label.is_empty(),
+            "every field must have a non-empty label (offender: {field:?})"
+        );
+        if let FieldKind::Enum {
+            options,
+            dynamic,
+            allow_custom,
+            ..
+        } = &field.kind
+        {
+            // Closed-vocabulary enums (no dynamic resolution, no free-form
+            // input) must declare at least one selectable option, otherwise
+            // nothing can be chosen.
+            if !*dynamic && !*allow_custom {
+                assert!(
+                    !options.is_empty(),
+                    "closed enum field '{}' must have at least one option",
+                    field.key
+                );
+            }
+        }
+    }
+
+    assert!(
+        schema.key_for_semantic(semantic::STATUS).is_some(),
+        "schema must declare a field with semantic 'status'"
+    );
+
+    let caps = adapter.capabilities();
+    assert!(!caps.name.is_empty(), "capabilities.name must not be empty");
+    assert_eq!(
+        caps.default_schema, schema.id,
+        "capabilities.default_schema must match schema.id"
+    );
+}
+
+/// Create → get → update title → update field → delete round-trip.
+pub fn check_crud_roundtrip<A: Adapter + ?Sized>(adapter: &A, opts: &ComplianceOptions) {
+    let marker = unique_marker();
+    let title = format!("Compliance CRUD {marker}");
+    let body = format!("Body for CRUD test {marker}.");
+    let req = make_create_request(&title, &body, opts);
+
+    let created = adapter
+        .create(&req)
+        .expect("create() must succeed for a well-formed request");
+    assert!(
+        !created.id.is_empty(),
+        "create() must return a SpecDoc with id populated"
+    );
+
+    let fetched = adapter
+        .get(&created.id)
+        .expect("get() must succeed for an id just returned by create()");
+    assert_eq!(
+        fetched.title, title,
+        "get() must return the same title that was created"
+    );
+    if let Some(content) = fetched
+        .fields
+        .get(&opts.content_key)
+        .and_then(|v| v.as_str())
+    {
+        assert!(
+            content.contains("Body for CRUD test"),
+            "body content must round-trip on get() — got {content:?}"
+        );
+    }
+
+    // Title update.
+    let new_title = format!("{title} (renamed)");
+    let updated = adapter
+        .update(
+            &created.id,
+            &UpdateRequest {
+                title: Some(new_title.clone()),
+                ..Default::default()
+            },
+        )
+        .expect("update(title) must succeed");
+    assert_eq!(updated.title, new_title, "title update must persist");
+    let refetched = adapter.get(&created.id).unwrap();
+    assert_eq!(
+        refetched.title, new_title,
+        "subsequent get() must reflect the updated title"
+    );
+
+    // Status update.
+    let mut fields = HashMap::new();
+    fields.insert(
+        opts.status_key.clone(),
+        FieldValue::String(opts.status_alt.clone()),
+    );
+    adapter
+        .update(
+            &created.id,
+            &UpdateRequest {
+                fields,
+                ..Default::default()
+            },
+        )
+        .expect("update(field) must succeed");
+    let after_status = adapter.get(&created.id).unwrap();
+    assert_eq!(
+        after_status.field_str(&opts.status_key),
+        Some(opts.status_alt.as_str()),
+        "subsequent get() must reflect the updated status"
+    );
+
+    // Delete — semantics depend on the adapter.
+    adapter.delete(&created.id).expect("delete() must succeed");
+    if opts.delete_is_archive {
+        adapter
+            .get(&created.id)
+            .expect("get() must still succeed after archive-delete");
+        let listed = adapter
+            .list(&ListFilter::default())
+            .expect("list() must succeed after archive");
+        assert!(
+            !listed.iter().any(|d| d.id == created.id),
+            "archived item must be excluded from list(default)"
+        );
+        let listed_all = adapter
+            .list(&ListFilter {
+                include_archived: true,
+                ..Default::default()
+            })
+            .expect("list(include_archived=true) must succeed");
+        assert!(
+            listed_all.iter().any(|d| d.id == created.id),
+            "archived item must reappear in list(include_archived=true)"
+        );
+    } else {
+        match adapter.get(&created.id) {
+            Err(AdapterError::NotFound(_)) => {}
+            other => panic!("expected NotFound after hard-delete, got {other:?}"),
+        }
+    }
+}
+
+/// `list()` returns created items and respects status + text filters and the
+/// archive flag.
+pub fn check_list_filter<A: Adapter + ?Sized>(adapter: &A, opts: &ComplianceOptions) {
+    let marker = unique_marker();
+    let title = format!("Compliance ListFilter {marker}");
+    let req = make_create_request(&title, "Body for list-filter test.", opts);
+    let created = adapter.create(&req).expect("create must succeed");
+
+    // Default list returns the item.
+    let listed = adapter
+        .list(&ListFilter::default())
+        .expect("list(default) must succeed");
+    assert!(
+        listed.iter().any(|d| d.id == created.id),
+        "list(default) must include the just-created item"
+    );
+
+    // Filter by status — created items must be findable by their active status.
+    let mut field_filter: HashMap<String, Vec<String>> = HashMap::new();
+    field_filter.insert(opts.status_key.clone(), vec![opts.status_active.clone()]);
+    let filtered = adapter
+        .list(&ListFilter {
+            fields: field_filter,
+            ..Default::default()
+        })
+        .expect("list(status filter) must succeed");
+    assert!(
+        filtered.iter().any(|d| d.id == created.id),
+        "filtering by the active status must include the created item"
+    );
+
+    // Free-text filter on the unique marker baked into the title.
+    let text_filtered = adapter
+        .list(&ListFilter {
+            text: Some(marker.clone()),
+            ..Default::default()
+        })
+        .expect("list(text filter) must succeed");
+    assert!(
+        text_filtered.iter().any(|d| d.id == created.id),
+        "free-text filter on a unique marker must match the created item"
+    );
+
+    // Archived items must be excluded from the default list.
+    if opts.delete_is_archive {
+        adapter.delete(&created.id).expect("delete must succeed");
+        let listed_after = adapter
+            .list(&ListFilter::default())
+            .expect("list after delete must succeed");
+        assert!(
+            !listed_after.iter().any(|d| d.id == created.id),
+            "list(default) must exclude archived items"
+        );
+    }
+}
+
+/// `search()` hits a unique marker and returns empty for a nonsense query.
+pub fn check_search<A: Adapter + ?Sized>(adapter: &A, opts: &ComplianceOptions) {
+    let marker = unique_marker();
+    let title = format!("Compliance Search {marker}");
+    let body = format!("Search body for {marker}");
+    let req = make_create_request(&title, &body, opts);
+    let created = adapter.create(&req).expect("create must succeed");
+
+    let hits = adapter
+        .search(&marker, &SearchOptions::default())
+        .expect("search() must succeed");
+    assert!(
+        hits.iter().any(|h| h.id == created.id),
+        "search by unique marker must return the created item — got {hits:?}"
+    );
+
+    let no_hits = adapter
+        .search(
+            "nonexistent_xyz_12345_compliance",
+            &SearchOptions::default(),
+        )
+        .expect("search() with no results must succeed");
+    assert!(
+        no_hits.is_empty(),
+        "search for a nonexistent term must return an empty vec — got {no_hits:?}"
+    );
+}
+
+/// Link round-trip — skipped silently when the adapter doesn't model links.
+pub fn check_links<A: Adapter + ?Sized>(adapter: &A, opts: &ComplianceOptions) {
+    if !opts.supports_links {
+        return;
+    }
+    let title = format!("Compliance Links {}", unique_marker());
+    let mut req = make_create_request(&title, "Body for link test.", opts);
+    req.links.push(ItemLink {
+        link_type: opts.link_type.clone(),
+        target_id: opts.link_target.clone(),
+        target_title: None,
+    });
+
+    let created = adapter.create(&req).expect("create with link must succeed");
+    let links = adapter
+        .get_links(&created.id)
+        .expect("get_links() must succeed");
+    assert!(
+        links
+            .iter()
+            .any(|l| l.link_type == opts.link_type && l.target_id == opts.link_target),
+        "the created link must round-trip on get_links() — got {links:?}"
+    );
+}
+
+/// `get` / `update` / `delete` on a nonexistent id all return `NotFound`.
+pub fn check_error_cases<A: Adapter + ?Sized>(adapter: &A, _opts: &ComplianceOptions) {
+    let missing = "nonexistent_xyz_12345_compliance";
+
+    match adapter.get(missing) {
+        Err(AdapterError::NotFound(_)) => {}
+        other => panic!("get(nonexistent) must return NotFound; got {other:?}"),
+    }
+
+    match adapter.update(missing, &UpdateRequest::default()) {
+        Err(AdapterError::NotFound(_)) => {}
+        other => panic!("update(nonexistent) must return NotFound; got {other:?}"),
+    }
+
+    match adapter.delete(missing) {
+        Err(AdapterError::NotFound(_)) => {}
+        other => panic!("delete(nonexistent) must return NotFound; got {other:?}"),
+    }
+}
+
+/// Run every compliance check sequentially against a single adapter instance.
+///
+/// Each check creates its own items with a unique marker so they don't
+/// interfere with each other.
+pub fn run_compliance_suite<A: Adapter + ?Sized>(adapter: &A, opts: &ComplianceOptions) {
+    check_schema_consistency(adapter, opts);
+    check_crud_roundtrip(adapter, opts);
+    check_list_filter(adapter, opts);
+    check_search(adapter, opts);
+    check_links(adapter, opts);
+    check_error_cases(adapter, opts);
+}
+
+/// Short unique marker used to disambiguate items created within one
+/// compliance run. Nanosecond clock keeps adjacent items distinct.
+fn unique_marker() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let bump = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("c{nanos:x}{bump:x}")
+}
+
+/// Generate one `#[test]` function per compliance category, all driven by a
+/// factory closure that returns `(adapter, fixture)`.
+///
+/// The fixture (e.g. a `TempDir` or a `mockito::ServerGuard`) is held alive
+/// by each test until it finishes. Each test calls the factory afresh so
+/// state from previous categories cannot bleed across tests.
+///
+/// The single-argument form uses [`ComplianceOptions::default`]. The
+/// two-argument form lets the adapter customise status values and skip
+/// flags.
+#[macro_export]
+macro_rules! adapter_compliance_tests {
+    ($factory:expr $(,)?) => {
+        $crate::adapter_compliance_tests!(
+            $factory,
+            $crate::adapters::test_harness::ComplianceOptions::default()
+        );
+    };
+    ($factory:expr, $opts:expr $(,)?) => {
+        #[test]
+        fn compliance_schema_consistency() {
+            let (adapter, _fixture) = ($factory)();
+            $crate::adapters::test_harness::check_schema_consistency(&adapter, &$opts);
+        }
+
+        #[test]
+        fn compliance_crud_roundtrip() {
+            let (adapter, _fixture) = ($factory)();
+            $crate::adapters::test_harness::check_crud_roundtrip(&adapter, &$opts);
+        }
+
+        #[test]
+        fn compliance_list_filter() {
+            let (adapter, _fixture) = ($factory)();
+            $crate::adapters::test_harness::check_list_filter(&adapter, &$opts);
+        }
+
+        #[test]
+        fn compliance_search() {
+            let (adapter, _fixture) = ($factory)();
+            $crate::adapters::test_harness::check_search(&adapter, &$opts);
+        }
+
+        #[test]
+        fn compliance_links() {
+            let (adapter, _fixture) = ($factory)();
+            $crate::adapters::test_harness::check_links(&adapter, &$opts);
+        }
+
+        #[test]
+        fn compliance_error_cases() {
+            let (adapter, _fixture) = ($factory)();
+            $crate::adapters::test_harness::check_error_cases(&adapter, &$opts);
+        }
+    };
+}


### PR DESCRIPTION
## Summary

Implements the adapter compliance test harness from #260 — a reusable behavioural-contract test suite that every `Adapter` implementation must satisfy.

- **New module** `rust/leanspec-core/src/adapters/test_harness.rs` with six contract groups: schema consistency, CRUD round-trip, list / filter, search, optional links, error cases.
- **Two entry points**: `run_compliance_suite(adapter, opts)` for one-shot use, and the `adapter_compliance_tests!` macro that emits one `#[test]` per category so each case shows up individually in `cargo test` output.
- **`ComplianceOptions`** lets adapters opt out of contract points that don't apply (hard-delete vs soft archive, link support) and supply backend-specific status values.
- **Exposed** via a new `test-utils` Cargo feature for out-of-tree adapters; always available inside the crate's own tests.
- **MarkdownAdapter** wires the full suite via a fresh-tempdir factory — all six categories pass.
- **GitHubAdapter** wires `check_schema_consistency` into its mockito unit tests and `run_compliance_suite` into its `#[ignore]`d real-API integration tests (feature `github-integration-tests`). A full mockito-stateful run is intentionally deferred — the existing per-endpoint mocks already cover behaviour, and a stateful in-memory mock can land in a follow-up.

Two markdown adapter bugs surfaced and were fixed in the process: `update()` and `delete()` on a nonexistent id now return `AdapterError::NotFound` instead of `AdapterError::IoError`, matching the contract every adapter is now held to.

## Test plan

- [x] `cargo test -p leanspec-core --lib compliance` — six compliance cases for MarkdownAdapter pass individually
- [x] `cargo test -p leanspec-core --features github --lib` — GitHubAdapter `passes_schema_compliance_check` plus full markdown suite (246 tests total)
- [x] `cargo test -p leanspec-core --features test-utils --no-run` — harness compiles behind the public feature flag
- [x] `cargo clippy -p leanspec-core --all-targets --features github,test-utils -- -D warnings` — clean
- [x] `cargo clippy -p leanspec-core --all-targets --features github-integration-tests -- -D warnings` — clean
- [x] `cargo fmt -p leanspec-core --check` — clean
- [ ] Integration suite against real GitHub API (requires `GITHUB_TOKEN`, `TEST_GITHUB_OWNER`, `TEST_GITHUB_REPO`) — runs locally with `--features github-integration-tests -- --ignored`

Closes #260

https://claude.ai/code/session_01CZJP9d8gzWqQHgz2UJKyhu

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZJP9d8gzWqQHgz2UJKyhu)_