### PR TITLE
feat(http): migrate read path to adapter layer (#261)

### DIFF
--- a/rust/leanspec-http/src/adapter_resolution.rs
+++ b/rust/leanspec-http/src/adapter_resolution.rs
@@ -1,0 +1,166 @@
+//! Shared helpers for resolving the active adapter for a project.
+//!
+//! Centralised so handlers (`/specs`, `/adapter`, `/schema`) and the file
+//! watcher in `state.rs` all use the exact same lookup order and config
+//! normalisation. Keeping this in one place stops watcher activation from
+//! drifting away from request-time adapter resolution.
+
+use std::path::{Path, PathBuf};
+
+use leanspec_core::adapters::{Adapter, AdapterConfig, AdapterError, AdapterRegistry};
+
+/// Candidate file paths (relative to the project root) for adapter config,
+/// in priority order. The legacy `provider:` files are honoured so existing
+/// projects keep working.
+pub const ADAPTER_CONFIG_CANDIDATES: &[&str] = &[
+    "leanspec.adapter.yaml",
+    ".lean-spec/adapter.yaml",
+    "leanspec.provider.yaml",
+    ".lean-spec/provider.yaml",
+];
+
+/// Returns the first adapter config file that exists under `project_root`.
+pub fn find_adapter_config(project_root: &Path) -> Option<PathBuf> {
+    ADAPTER_CONFIG_CANDIDATES
+        .iter()
+        .map(|c| project_root.join(c))
+        .find(|p| p.exists())
+}
+
+/// Load the adapter config for a project. Falls back to a markdown adapter
+/// rooted at `specs_dir` when no config file is present.
+///
+/// When the loaded config is a markdown adapter with a relative
+/// `settings.directory`, the directory is resolved against `project_root` so
+/// the adapter reads from the right tree regardless of the server's CWD.
+pub fn load_adapter_config(
+    project_root: &Path,
+    specs_dir: &Path,
+) -> Result<AdapterConfig, AdapterError> {
+    let mut config = if let Some(path) = find_adapter_config(project_root) {
+        AdapterRegistry::load_config(&path)?
+    } else {
+        AdapterConfig {
+            adapter: "markdown".into(),
+            settings: serde_json::json!({ "directory": specs_dir.to_string_lossy().as_ref() }),
+        }
+    };
+
+    normalise_markdown_directory(&mut config, project_root, specs_dir);
+    Ok(config)
+}
+
+/// Resolve and instantiate the active adapter for a project.
+pub fn resolve_adapter(
+    project_root: &Path,
+    specs_dir: &Path,
+) -> Result<Box<dyn Adapter>, AdapterError> {
+    let config = load_adapter_config(project_root, specs_dir)?;
+    AdapterRegistry::create(&config)
+}
+
+/// When the active adapter is markdown, rewrite a relative `settings.directory`
+/// (e.g. `"specs"`) so it's anchored at the project root. Falls back to
+/// `specs_dir` when the config omits the field entirely.
+fn normalise_markdown_directory(config: &mut AdapterConfig, project_root: &Path, specs_dir: &Path) {
+    if config.adapter != "markdown" {
+        return;
+    }
+
+    let current = config
+        .settings
+        .get("directory")
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from);
+
+    let resolved = match current {
+        Some(dir) if dir.is_absolute() => dir,
+        Some(dir) => project_root.join(dir),
+        None => specs_dir.to_path_buf(),
+    };
+
+    if let Some(obj) = config.settings.as_object_mut() {
+        obj.insert(
+            "directory".into(),
+            serde_json::Value::String(resolved.to_string_lossy().into_owned()),
+        );
+    } else {
+        config.settings = serde_json::json!({ "directory": resolved.to_string_lossy().as_ref() });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn fallback_uses_specs_dir() {
+        let tmp = TempDir::new().unwrap();
+        let specs = tmp.path().join("specs");
+        fs::create_dir_all(&specs).unwrap();
+
+        let config = load_adapter_config(tmp.path(), &specs).unwrap();
+        assert_eq!(config.adapter, "markdown");
+        assert_eq!(
+            config.settings.get("directory").and_then(|v| v.as_str()),
+            Some(specs.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn relative_directory_resolved_against_project_root() {
+        let tmp = TempDir::new().unwrap();
+        let project = tmp.path();
+        let yaml = project.join("leanspec.adapter.yaml");
+        fs::write(&yaml, "adapter: markdown\ndirectory: docs/specs\n").unwrap();
+
+        let specs = project.join("specs");
+        let config = load_adapter_config(project, &specs).unwrap();
+        let resolved = config
+            .settings
+            .get("directory")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert_eq!(resolved, project.join("docs/specs").to_string_lossy());
+    }
+
+    #[test]
+    fn absolute_directory_preserved() {
+        let tmp = TempDir::new().unwrap();
+        let project = tmp.path();
+        let yaml = project.join("leanspec.adapter.yaml");
+        let abs = project.join("absolute-specs");
+        fs::write(
+            &yaml,
+            format!("adapter: markdown\ndirectory: {}\n", abs.display()),
+        )
+        .unwrap();
+
+        let specs = project.join("specs");
+        let config = load_adapter_config(project, &specs).unwrap();
+        assert_eq!(
+            config.settings.get("directory").and_then(|v| v.as_str()),
+            Some(abs.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn non_markdown_adapter_left_alone() {
+        let tmp = TempDir::new().unwrap();
+        let project = tmp.path();
+        let yaml = project.join("leanspec.adapter.yaml");
+        fs::write(
+            &yaml,
+            "adapter: github\nowner: acme\nrepo: backend\ntoken_env: TEST_TOKEN\n",
+        )
+        .unwrap();
+
+        let specs = project.join("specs");
+        let config = load_adapter_config(project, &specs).unwrap();
+        assert_eq!(config.adapter, "github");
+        // No `directory` key was added.
+        assert!(config.settings.get("directory").is_none());
+    }
+}

--- a/rust/leanspec-http/src/handlers/adapter.rs
+++ b/rust/leanspec-http/src/handlers/adapter.rs
@@ -6,46 +6,16 @@
 
 #![allow(clippy::result_large_err)]
 
-use std::path::Path as FsPath;
-
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::Json;
-use leanspec_core::adapters::{AdapterCapabilities, AdapterConfig, AdapterRegistry};
+use leanspec_core::adapters::AdapterCapabilities;
 use leanspec_core::SpecSchema;
 
+use crate::adapter_resolution::resolve_adapter;
 use crate::error::ApiError;
 use crate::state::AppState;
 use crate::utils::resolve_project;
-
-/// Candidate file paths (relative to the project root) for adapter config,
-/// in priority order. The legacy `provider:` files are honoured so existing
-/// projects keep working.
-const ADAPTER_CONFIG_CANDIDATES: &[&str] = &[
-    "leanspec.adapter.yaml",
-    ".lean-spec/adapter.yaml",
-    "leanspec.provider.yaml",
-    ".lean-spec/provider.yaml",
-];
-
-fn resolve_adapter_for_project(
-    project_root: &FsPath,
-    specs_dir: &FsPath,
-) -> Result<Box<dyn leanspec_core::Adapter>, (StatusCode, Json<ApiError>)> {
-    for candidate in ADAPTER_CONFIG_CANDIDATES {
-        let path = project_root.join(candidate);
-        if path.exists() {
-            let config = AdapterRegistry::load_config(&path).map_err(api_error)?;
-            return AdapterRegistry::create(&config).map_err(api_error);
-        }
-    }
-
-    let config = AdapterConfig {
-        adapter: "markdown".into(),
-        settings: serde_json::json!({ "directory": specs_dir.to_string_lossy().as_ref() }),
-    };
-    AdapterRegistry::create(&config).map_err(api_error)
-}
 
 fn api_error(err: leanspec_core::AdapterError) -> (StatusCode, Json<ApiError>) {
     (
@@ -60,7 +30,7 @@ pub async fn get_project_adapter_capabilities(
     Path(project_id): Path<String>,
 ) -> Result<Json<AdapterCapabilities>, (StatusCode, Json<ApiError>)> {
     let project = resolve_project(&state, &project_id).await?;
-    let adapter = resolve_adapter_for_project(&project.path, &project.specs_dir)?;
+    let adapter = resolve_adapter(&project.path, &project.specs_dir).map_err(api_error)?;
     Ok(Json(adapter.capabilities().clone()))
 }
 
@@ -73,6 +43,6 @@ pub async fn get_project_schema(
     Path(project_id): Path<String>,
 ) -> Result<Json<SpecSchema>, (StatusCode, Json<ApiError>)> {
     let project = resolve_project(&state, &project_id).await?;
-    let adapter = resolve_adapter_for_project(&project.path, &project.specs_dir)?;
+    let adapter = resolve_adapter(&project.path, &project.specs_dir).map_err(api_error)?;
     Ok(Json(adapter.schema().clone()))
 }

--- a/rust/leanspec-http/src/handlers/adapter.rs
+++ b/rust/leanspec-http/src/handlers/adapter.rs
@@ -1,8 +1,8 @@
-//! Adapter introspection endpoint.
+//! Adapter introspection endpoints.
 //!
-//! Returns the active [`leanspec_core::Adapter`]'s capabilities for a given
-//! project so clients (UI, agents) can build adapter-aware workflows without
-//! assuming markdown-specific conventions.
+//! Surfaces the active [`leanspec_core::Adapter`]'s capabilities and schema
+//! for a given project so clients (UI, agents) can build adapter-aware
+//! workflows without assuming markdown-specific conventions.
 
 #![allow(clippy::result_large_err)]
 
@@ -12,6 +12,7 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::Json;
 use leanspec_core::adapters::{AdapterCapabilities, AdapterConfig, AdapterRegistry};
+use leanspec_core::SpecSchema;
 
 use crate::error::ApiError;
 use crate::state::AppState;
@@ -39,8 +40,6 @@ fn resolve_adapter_for_project(
         }
     }
 
-    // No adapter config — fall back to the markdown adapter pointed at the
-    // project's declared specs directory.
     let config = AdapterConfig {
         adapter: "markdown".into(),
         settings: serde_json::json!({ "directory": specs_dir.to_string_lossy().as_ref() }),
@@ -63,4 +62,17 @@ pub async fn get_project_adapter_capabilities(
     let project = resolve_project(&state, &project_id).await?;
     let adapter = resolve_adapter_for_project(&project.path, &project.specs_dir)?;
     Ok(Json(adapter.capabilities().clone()))
+}
+
+/// GET /api/projects/{id}/schema
+///
+/// Returns the active adapter's `SpecSchema` so the UI can render dynamic
+/// field sets without hard-coding adapter-specific conventions.
+pub async fn get_project_schema(
+    State(state): State<AppState>,
+    Path(project_id): Path<String>,
+) -> Result<Json<SpecSchema>, (StatusCode, Json<ApiError>)> {
+    let project = resolve_project(&state, &project_id).await?;
+    let adapter = resolve_adapter_for_project(&project.path, &project.specs_dir)?;
+    Ok(Json(adapter.schema().clone()))
 }

--- a/rust/leanspec-http/src/handlers/specs/compute.rs
+++ b/rust/leanspec-http/src/handlers/specs/compute.rs
@@ -2,53 +2,127 @@
 
 #![allow(clippy::result_large_err)]
 
-use axum::extract::{Path, State};
-use axum::http::StatusCode;
-use axum::Json;
 use std::collections::HashMap;
 use std::fs;
 
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+
+use leanspec_core::adapters::markdown::SpecInfo;
+use leanspec_core::adapters::ListFilter;
 use leanspec_core::{
     global_frontmatter_validator, global_structure_validator, global_token_count_validator,
-    global_token_counter, SpecStats, ValidationResult,
+    global_token_counter, semantic, FieldValue, FrontmatterParser, SpecDoc, SpecSchema,
+    ValidationResult,
 };
 
 use crate::error::{ApiError, ApiResult};
 use crate::state::AppState;
 
 use crate::types::{
-    DetailedBreakdown, SectionTokenCount, SpecTokenResponse, SpecValidationError,
-    SpecValidationResponse, StatsResponse, TokenBreakdown,
+    DependencyEdge, DependencyGraphResponse, DependencyNode, DetailedBreakdown, PriorityCountItem,
+    SectionTokenCount, SpecTokenResponse, SpecValidationError, SpecValidationResponse,
+    StatsResponse, StatusCountItem, TokenBreakdown,
 };
 
-use super::helpers::{get_spec_loader, token_status_label, validation_status_label};
+use super::helpers::{
+    adapter_error, get_adapter_and_project, require_markdown_adapter, resolve_markdown_spec_path,
+    token_status_label, validation_status_label,
+};
+
+fn doc_content(doc: &SpecDoc) -> &str {
+    doc.fields
+        .get("content")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+}
+
+fn doc_semantic_str<'a>(doc: &'a SpecDoc, schema: &SpecSchema, sem: &str) -> Option<&'a str> {
+    let key = schema.key_for_semantic(sem)?;
+    doc.fields.get(key).and_then(|v| v.as_str())
+}
+
+fn doc_semantic_strings(doc: &SpecDoc, schema: &SpecSchema, sem: &str) -> Vec<String> {
+    let key = match schema.key_for_semantic(sem) {
+        Some(k) => k,
+        None => return Vec::new(),
+    };
+    match doc.fields.get(key) {
+        Some(FieldValue::Strings(v)) => v.clone(),
+        _ => Vec::new(),
+    }
+}
+
+/// Reconstruct a `SpecInfo`-shaped value from a `SpecDoc` and on-disk path for
+/// the markdown-only validators that still take `&SpecInfo`. This is a
+/// short-term bridge: when validators move to the schema-driven model the
+/// helper can be removed.
+fn spec_info_for_validation(
+    doc: &SpecDoc,
+    file_path: std::path::PathBuf,
+) -> Result<SpecInfo, (StatusCode, Json<ApiError>)> {
+    let content = fs::read_to_string(&file_path).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiError::internal_error(&e.to_string())),
+        )
+    })?;
+
+    let parser = FrontmatterParser::new();
+    let (frontmatter, body) = parser.parse(&content).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiError::internal_error(&e.to_string())),
+        )
+    })?;
+
+    let title = body
+        .lines()
+        .find(|l| l.starts_with("# "))
+        .map(|l| l.trim_start_matches("# ").to_string())
+        .unwrap_or_else(|| doc.title.clone());
+
+    Ok(SpecInfo {
+        path: doc.id.clone(),
+        title,
+        frontmatter,
+        content: body,
+        file_path,
+        is_sub_spec: false,
+        parent_spec: None,
+    })
+}
 
 /// GET /api/projects/:projectId/specs/:spec/tokens - Get token counts for a spec
 pub async fn get_project_spec_tokens(
     State(state): State<AppState>,
     Path((project_id, spec_id)): Path<(String, String)>,
 ) -> ApiResult<Json<SpecTokenResponse>> {
-    let (loader, _project) = get_spec_loader(&state, &project_id).await?;
-    let spec = loader.load(&spec_id).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
+    let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
 
-    let spec = spec.ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ApiError::spec_not_found(&spec_id)),
-        )
-    })?;
-
-    let content = fs::read_to_string(&spec.file_path).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
+    // Token counting works on raw markdown including frontmatter. For markdown
+    // projects we read the file; for other adapters we fall back to the body
+    // content the adapter returned.
+    let content = if adapter.capabilities().name == "markdown" {
+        adapter.get(&spec_id).map_err(adapter_error)?;
+        let file_path =
+            resolve_markdown_spec_path(&project.specs_dir, &spec_id).ok_or_else(|| {
+                (
+                    StatusCode::NOT_FOUND,
+                    Json(ApiError::spec_not_found(&spec_id)),
+                )
+            })?;
+        fs::read_to_string(&file_path).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiError::internal_error(&e.to_string())),
+            )
+        })?
+    } else {
+        let doc = adapter.get(&spec_id).map_err(adapter_error)?;
+        doc_content(&doc).to_string()
+    };
 
     let counter = global_token_counter();
     let result = counter.count_spec(&content);
@@ -79,33 +153,33 @@ pub async fn get_project_spec_tokens(
 }
 
 /// GET /api/projects/:projectId/specs/:spec/validation - Validate a spec
+///
+/// Markdown-only. Returns HTTP 422 for other adapters.
 pub async fn get_project_spec_validation(
     State(state): State<AppState>,
     Path((project_id, spec_id)): Path<(String, String)>,
 ) -> ApiResult<Json<SpecValidationResponse>> {
-    let (loader, _project) = get_spec_loader(&state, &project_id).await?;
-    let spec = loader.load(&spec_id).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
+    let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
+    require_markdown_adapter(adapter.as_ref())?;
 
-    let spec = spec.ok_or_else(|| {
+    let doc = adapter.get(&spec_id).map_err(adapter_error)?;
+    let file_path = resolve_markdown_spec_path(&project.specs_dir, &spec_id).ok_or_else(|| {
         (
             StatusCode::NOT_FOUND,
             Json(ApiError::spec_not_found(&spec_id)),
         )
     })?;
 
+    let spec_info = spec_info_for_validation(&doc, file_path)?;
+
     let fm_validator = global_frontmatter_validator();
     let struct_validator = global_structure_validator();
     let token_validator = global_token_count_validator();
 
-    let mut result = ValidationResult::new(&spec.path);
-    result.merge(fm_validator.validate(&spec));
-    result.merge(struct_validator.validate(&spec));
-    result.merge(token_validator.validate(&spec));
+    let mut result = ValidationResult::new(&spec_info.path);
+    result.merge(fm_validator.validate(&spec_info));
+    result.merge(struct_validator.validate(&spec_info));
+    result.merge(token_validator.validate(&spec_info));
 
     let errors = result
         .errors
@@ -130,70 +204,155 @@ pub async fn get_project_stats(
     State(state): State<AppState>,
     Path(project_id): Path<String>,
 ) -> ApiResult<Json<StatsResponse>> {
-    let (loader, project) = get_spec_loader(&state, &project_id).await?;
+    let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
+    let schema = adapter.schema();
 
-    let all_specs = loader.load_all().map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
+    let docs = adapter
+        .list(&ListFilter {
+            include_archived: true,
+            ..Default::default()
+        })
+        .map_err(adapter_error)?;
 
-    let stats = SpecStats::compute(&all_specs);
+    let specs_by_status = build_status_counts(&docs, schema);
+    let specs_by_priority = build_priority_counts(&docs, schema);
+    let completion_rate = completion_rate(&specs_by_status);
 
-    Ok(Json(StatsResponse::from_project_stats(stats, &project.id)))
+    Ok(Json(StatsResponse {
+        total_projects: 1,
+        total_specs: docs.len(),
+        specs_by_status,
+        specs_by_priority,
+        completion_rate,
+        project_id: Some(project.id),
+    }))
+}
+
+fn build_status_counts(docs: &[SpecDoc], schema: &SpecSchema) -> Vec<StatusCountItem> {
+    // Keep the canonical markdown status ordering at minimum, then append any
+    // adapter-specific values seen in the data.
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for doc in docs {
+        let status = doc_semantic_str(doc, schema, semantic::STATUS).unwrap_or("");
+        if status.is_empty() {
+            continue;
+        }
+        *counts.entry(status.to_string()).or_insert(0) += 1;
+    }
+
+    let canonical = ["draft", "planned", "in-progress", "complete", "archived"];
+    let mut items: Vec<StatusCountItem> = canonical
+        .iter()
+        .map(|s| StatusCountItem {
+            status: (*s).to_string(),
+            count: counts.remove(*s).unwrap_or(0),
+        })
+        .collect();
+    let mut extras: Vec<(String, usize)> = counts.into_iter().collect();
+    extras.sort_by(|a, b| a.0.cmp(&b.0));
+    for (status, count) in extras {
+        items.push(StatusCountItem { status, count });
+    }
+    items
+}
+
+fn build_priority_counts(docs: &[SpecDoc], schema: &SpecSchema) -> Vec<PriorityCountItem> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for doc in docs {
+        if let Some(priority) = doc_semantic_str(doc, schema, semantic::PRIORITY) {
+            if !priority.is_empty() {
+                *counts.entry(priority.to_string()).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let canonical = ["low", "medium", "high", "critical"];
+    let mut items: Vec<PriorityCountItem> = canonical
+        .iter()
+        .map(|p| PriorityCountItem {
+            priority: (*p).to_string(),
+            count: counts.remove(*p).unwrap_or(0),
+        })
+        .collect();
+    let mut extras: Vec<(String, usize)> = counts.into_iter().collect();
+    extras.sort_by(|a, b| a.0.cmp(&b.0));
+    for (priority, count) in extras {
+        items.push(PriorityCountItem { priority, count });
+    }
+    items
+}
+
+fn completion_rate(counts: &[StatusCountItem]) -> f64 {
+    let total: usize = counts.iter().map(|c| c.count).sum();
+    if total == 0 {
+        return 0.0;
+    }
+    let complete = counts
+        .iter()
+        .find(|c| c.status == "complete")
+        .map(|c| c.count)
+        .unwrap_or(0);
+    (complete as f64 / total as f64) * 100.0
 }
 
 /// GET /api/projects/:projectId/dependencies - Dependency graph for a project
+///
+/// Markdown-only. Returns HTTP 422 for other adapters.
 pub async fn get_project_dependencies(
     State(state): State<AppState>,
     Path(project_id): Path<String>,
-) -> ApiResult<Json<crate::types::DependencyGraphResponse>> {
-    let (loader, project) = get_spec_loader(&state, &project_id).await?;
+) -> ApiResult<Json<DependencyGraphResponse>> {
+    let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
+    require_markdown_adapter(adapter.as_ref())?;
 
-    let all_specs = loader.load_all().map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
+    let schema = adapter.schema();
+    let docs = adapter
+        .list(&ListFilter {
+            include_archived: true,
+            ..Default::default()
+        })
+        .map_err(adapter_error)?;
 
-    let mut nodes = Vec::new();
+    let known_ids: std::collections::HashSet<String> = docs.iter().map(|d| d.id.clone()).collect();
+    let mut nodes = Vec::with_capacity(docs.len());
     let mut edges = Vec::new();
-    let spec_map: HashMap<String, _> = all_specs.iter().map(|s| (s.path.clone(), s)).collect();
 
-    for spec in &all_specs {
-        nodes.push(crate::types::DependencyNode {
-            id: spec.path.clone(),
-            name: if !spec.title.is_empty() && spec.title != spec.path {
-                spec.title.clone()
+    for doc in &docs {
+        nodes.push(DependencyNode {
+            id: doc.id.clone(),
+            name: if !doc.title.is_empty() && doc.title != doc.id {
+                doc.title.clone()
             } else {
-                spec.path.clone()
+                doc.id.clone()
             },
-            number: spec.number().unwrap_or(0),
-            status: spec.frontmatter.status.to_string(),
-            priority: spec
-                .frontmatter
-                .priority
-                .map(|p| p.to_string())
-                .unwrap_or_else(|| "medium".to_string()),
-            tags: spec.frontmatter.tags.clone(),
+            number: doc
+                .id
+                .split('-')
+                .next()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0),
+            status: doc_semantic_str(doc, schema, semantic::STATUS)
+                .unwrap_or("")
+                .to_string(),
+            priority: doc_semantic_str(doc, schema, semantic::PRIORITY)
+                .unwrap_or("medium")
+                .to_string(),
+            tags: doc_semantic_strings(doc, schema, semantic::TAGS),
         });
 
-        for dep in &spec.frontmatter.depends_on {
-            if spec_map.contains_key(dep) {
-                edges.push(crate::types::DependencyEdge {
+        for link in &doc.links {
+            if link.link_type == "depends_on" && known_ids.contains(&link.target_id) {
+                edges.push(DependencyEdge {
                     // Edge direction: dependency -> dependent
-                    // If spec A depends_on B, draw B -> A
-                    source: dep.clone(),
-                    target: spec.path.clone(),
+                    source: link.target_id.clone(),
+                    target: doc.id.clone(),
                     r#type: Some("dependsOn".to_string()),
                 });
             }
         }
     }
 
-    Ok(Json(crate::types::DependencyGraphResponse {
+    Ok(Json(DependencyGraphResponse {
         project_id: Some(project.id),
         nodes,
         edges,

--- a/rust/leanspec-http/src/handlers/specs/helpers.rs
+++ b/rust/leanspec-http/src/handlers/specs/helpers.rs
@@ -5,27 +5,18 @@
 use axum::http::StatusCode;
 use axum::Json;
 use sha2::{Digest, Sha256};
-use std::path::{Path as FsPath, PathBuf};
+use std::path::{Component, Path as FsPath, PathBuf};
 
-use leanspec_core::adapters::{Adapter, AdapterConfig, AdapterError, AdapterRegistry};
+use leanspec_core::adapters::{Adapter, AdapterError};
 use leanspec_core::{LeanSpecConfig, TokenStatus, ValidationResult};
 
+use crate::adapter_resolution::resolve_adapter;
 use crate::error::ApiError;
 use crate::project_registry::Project;
 use crate::state::AppState;
 use crate::utils::resolve_project;
 
 use crate::types::SubSpec;
-
-/// Candidate file paths (relative to the project root) for adapter config,
-/// in priority order. Legacy `provider:` files are honoured so existing
-/// projects keep working.
-const ADAPTER_CONFIG_CANDIDATES: &[&str] = &[
-    "leanspec.adapter.yaml",
-    ".lean-spec/adapter.yaml",
-    "leanspec.provider.yaml",
-    ".lean-spec/provider.yaml",
-];
 
 /// Resolve the active adapter for a project plus the project record itself.
 ///
@@ -37,27 +28,8 @@ pub(super) async fn get_adapter_and_project(
     project_id: &str,
 ) -> Result<(Box<dyn Adapter>, Project), (StatusCode, Json<ApiError>)> {
     let project = resolve_project(state, project_id).await?;
-    let adapter = resolve_adapter_for_project(&project.path, &project.specs_dir)?;
+    let adapter = resolve_adapter(&project.path, &project.specs_dir).map_err(adapter_init_error)?;
     Ok((adapter, project))
-}
-
-pub(super) fn resolve_adapter_for_project(
-    project_root: &FsPath,
-    specs_dir: &FsPath,
-) -> Result<Box<dyn Adapter>, (StatusCode, Json<ApiError>)> {
-    for candidate in ADAPTER_CONFIG_CANDIDATES {
-        let path = project_root.join(candidate);
-        if path.exists() {
-            let config = AdapterRegistry::load_config(&path).map_err(adapter_init_error)?;
-            return AdapterRegistry::create(&config).map_err(adapter_init_error);
-        }
-    }
-
-    let config = AdapterConfig {
-        adapter: "markdown".into(),
-        settings: serde_json::json!({ "directory": specs_dir.to_string_lossy().as_ref() }),
-    };
-    AdapterRegistry::create(&config).map_err(adapter_init_error)
 }
 
 fn adapter_init_error(err: AdapterError) -> (StatusCode, Json<ApiError>) {
@@ -116,15 +88,47 @@ pub(super) fn require_markdown_adapter(
     }
 }
 
+/// Reject spec ids that could escape the specs directory (path separators,
+/// `..`, absolute paths). Returns `None` for any id that's safe to use.
+pub(super) fn invalid_spec_id(spec_id: &str) -> bool {
+    if spec_id.is_empty() {
+        return true;
+    }
+    let path = FsPath::new(spec_id);
+    if path.is_absolute() {
+        return true;
+    }
+    path.components().any(|c| {
+        matches!(
+            c,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) || spec_id.contains('/')
+        || spec_id.contains('\\')
+}
+
 /// Try to resolve a spec id to a `README.md` path under the project's specs
 /// directory. Used by markdown-specific handlers (raw read/write, sub-spec
 /// access) that operate on files directly.
+///
+/// Refuses any spec id that contains path separators, `..`, or is absolute
+/// — those can never name a real spec dir and would let callers escape the
+/// project's specs root.
 pub(super) fn resolve_markdown_spec_path(specs_dir: &FsPath, spec_id: &str) -> Option<PathBuf> {
+    if invalid_spec_id(spec_id) {
+        return None;
+    }
+
     let direct = specs_dir.join(spec_id).join("README.md");
     if direct.exists() {
         return Some(direct);
     }
 
+    // Fuzzy match by directory-name prefix. Mirrors the markdown loader's
+    // historical behaviour ("001" matches "001-first-spec") but is narrower
+    // than the old `contains` heuristic: we only accept ids that look like a
+    // numeric prefix of the directory name to avoid resolving "01" or "1"
+    // onto an unrelated spec.
     let entries = std::fs::read_dir(specs_dir).ok()?;
     for entry in entries.flatten() {
         let path = entry.path();
@@ -134,7 +138,7 @@ pub(super) fn resolve_markdown_spec_path(specs_dir: &FsPath, spec_id: &str) -> O
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
             continue;
         };
-        if name.contains(spec_id) || spec_id.contains(name) {
+        if name == spec_id || directory_matches_id(name, spec_id) {
             let readme = path.join("README.md");
             if readme.exists() {
                 return Some(readme);
@@ -142,6 +146,20 @@ pub(super) fn resolve_markdown_spec_path(specs_dir: &FsPath, spec_id: &str) -> O
         }
     }
     None
+}
+
+/// Returns true when a spec id is a legitimate fuzzy match for the directory
+/// name — either the directory's numeric prefix (e.g. `001` ↔ `001-foo`) or
+/// the slug portion (`foo` ↔ `001-foo`).
+fn directory_matches_id(dir_name: &str, spec_id: &str) -> bool {
+    let Some((prefix, suffix)) = dir_name.split_once('-') else {
+        return false;
+    };
+    if prefix.is_empty() || !prefix.chars().all(|c| c.is_ascii_digit()) {
+        return false;
+    }
+    // Exact prefix match: "001" matches "001-foo" but "01" does not.
+    prefix == spec_id || suffix == spec_id
 }
 
 pub(super) fn hash_raw_content(content: &str) -> String {
@@ -284,4 +302,72 @@ pub(super) fn load_project_config(project_path: &FsPath) -> Option<LeanSpecConfi
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn invalid_spec_id_rejects_traversal() {
+        assert!(invalid_spec_id(""));
+        assert!(invalid_spec_id(".."));
+        assert!(invalid_spec_id("../etc"));
+        assert!(invalid_spec_id("001/../other"));
+        assert!(invalid_spec_id("/abs/path"));
+        assert!(invalid_spec_id("foo/bar"));
+        assert!(invalid_spec_id("foo\\bar"));
+    }
+
+    #[test]
+    fn invalid_spec_id_accepts_normal_ids() {
+        assert!(!invalid_spec_id("001-first-spec"));
+        assert!(!invalid_spec_id("001"));
+        assert!(!invalid_spec_id("my-spec"));
+    }
+
+    #[test]
+    fn resolve_markdown_spec_path_blocks_traversal() {
+        let tmp = TempDir::new().unwrap();
+        let specs = tmp.path().join("specs");
+        fs::create_dir_all(&specs).unwrap();
+        let outside = tmp.path().join("outside");
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join("README.md"), "secret").unwrap();
+
+        assert!(resolve_markdown_spec_path(&specs, "../outside").is_none());
+        assert!(resolve_markdown_spec_path(&specs, "/etc/passwd").is_none());
+        assert!(resolve_markdown_spec_path(&specs, "").is_none());
+    }
+
+    #[test]
+    fn resolve_markdown_spec_path_finds_direct_and_fuzzy() {
+        let tmp = TempDir::new().unwrap();
+        let specs = tmp.path().join("specs");
+        let spec_dir = specs.join("001-first-spec");
+        fs::create_dir_all(&spec_dir).unwrap();
+        fs::write(spec_dir.join("README.md"), "body").unwrap();
+
+        // Exact match.
+        assert!(resolve_markdown_spec_path(&specs, "001-first-spec").is_some());
+        // Numeric prefix fuzzy.
+        assert!(resolve_markdown_spec_path(&specs, "001").is_some());
+        // Slug fuzzy.
+        assert!(resolve_markdown_spec_path(&specs, "first-spec").is_some());
+        // Bogus numeric prefix doesn't match.
+        assert!(resolve_markdown_spec_path(&specs, "01").is_none());
+        assert!(resolve_markdown_spec_path(&specs, "9").is_none());
+    }
+
+    #[test]
+    fn directory_matches_id_handles_prefix_and_slug() {
+        assert!(directory_matches_id("001-foo", "001"));
+        assert!(directory_matches_id("001-foo", "foo"));
+        assert!(!directory_matches_id("001-foo", "00"));
+        assert!(!directory_matches_id("001-foo", "1"));
+        assert!(!directory_matches_id("no-prefix", "no"));
+        assert!(!directory_matches_id("", "001"));
+    }
 }

--- a/rust/leanspec-http/src/handlers/specs/helpers.rs
+++ b/rust/leanspec-http/src/handlers/specs/helpers.rs
@@ -5,9 +5,10 @@
 use axum::http::StatusCode;
 use axum::Json;
 use sha2::{Digest, Sha256};
-use std::path::Path as FsPath;
+use std::path::{Path as FsPath, PathBuf};
 
-use leanspec_core::{LeanSpecConfig, SpecLoader, TokenStatus, ValidationResult};
+use leanspec_core::adapters::{Adapter, AdapterConfig, AdapterError, AdapterRegistry};
+use leanspec_core::{LeanSpecConfig, TokenStatus, ValidationResult};
 
 use crate::error::ApiError;
 use crate::project_registry::Project;
@@ -16,14 +17,131 @@ use crate::utils::resolve_project;
 
 use crate::types::SubSpec;
 
-/// Helper to get the spec loader for a project (required project_id)
-pub(super) async fn get_spec_loader(
+/// Candidate file paths (relative to the project root) for adapter config,
+/// in priority order. Legacy `provider:` files are honoured so existing
+/// projects keep working.
+const ADAPTER_CONFIG_CANDIDATES: &[&str] = &[
+    "leanspec.adapter.yaml",
+    ".lean-spec/adapter.yaml",
+    "leanspec.provider.yaml",
+    ".lean-spec/provider.yaml",
+];
+
+/// Resolve the active adapter for a project plus the project record itself.
+///
+/// Adapter config is read from the project root using the same lookup order
+/// as the CLI. When no config file is present we fall back to the markdown
+/// adapter pointed at the project's declared `specs_dir`.
+pub(super) async fn get_adapter_and_project(
     state: &AppState,
     project_id: &str,
-) -> Result<(SpecLoader, Project), (StatusCode, Json<ApiError>)> {
+) -> Result<(Box<dyn Adapter>, Project), (StatusCode, Json<ApiError>)> {
     let project = resolve_project(state, project_id).await?;
-    let specs_dir = project.specs_dir.clone();
-    Ok((SpecLoader::new(&specs_dir), project))
+    let adapter = resolve_adapter_for_project(&project.path, &project.specs_dir)?;
+    Ok((adapter, project))
+}
+
+pub(super) fn resolve_adapter_for_project(
+    project_root: &FsPath,
+    specs_dir: &FsPath,
+) -> Result<Box<dyn Adapter>, (StatusCode, Json<ApiError>)> {
+    for candidate in ADAPTER_CONFIG_CANDIDATES {
+        let path = project_root.join(candidate);
+        if path.exists() {
+            let config = AdapterRegistry::load_config(&path).map_err(adapter_init_error)?;
+            return AdapterRegistry::create(&config).map_err(adapter_init_error);
+        }
+    }
+
+    let config = AdapterConfig {
+        adapter: "markdown".into(),
+        settings: serde_json::json!({ "directory": specs_dir.to_string_lossy().as_ref() }),
+    };
+    AdapterRegistry::create(&config).map_err(adapter_init_error)
+}
+
+fn adapter_init_error(err: AdapterError) -> (StatusCode, Json<ApiError>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ApiError::new("ADAPTER_INIT_FAILED", err.to_string())),
+    )
+}
+
+/// Map any [`AdapterError`] to an HTTP error response.
+pub(super) fn adapter_error(err: AdapterError) -> (StatusCode, Json<ApiError>) {
+    match err {
+        AdapterError::NotFound(id) => (StatusCode::NOT_FOUND, Json(ApiError::spec_not_found(&id))),
+        AdapterError::NotSupported { .. } => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ApiError::new("ADAPTER_NOT_SUPPORTED", err.to_string())),
+        ),
+        AdapterError::InvalidField { .. } => (
+            StatusCode::BAD_REQUEST,
+            Json(ApiError::invalid_request(&err.to_string())),
+        ),
+        AdapterError::AuthError { .. } => (
+            StatusCode::UNAUTHORIZED,
+            Json(ApiError::unauthorized(&err.to_string())),
+        ),
+        AdapterError::ConfigError(_) | AdapterError::ParseError { .. } => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiError::internal_error(&err.to_string())),
+        ),
+        AdapterError::BackendError { .. } | AdapterError::RateLimit { .. } => (
+            StatusCode::BAD_GATEWAY,
+            Json(ApiError::internal_error(&err.to_string())),
+        ),
+        AdapterError::IoError(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiError::internal_error(&e.to_string())),
+        ),
+    }
+}
+
+/// Guard a handler so it only runs against the markdown adapter, with a
+/// consistent 422 error otherwise.
+pub(super) fn require_markdown_adapter(
+    adapter: &dyn Adapter,
+) -> Result<(), (StatusCode, Json<ApiError>)> {
+    if adapter.capabilities().name == "markdown" {
+        Ok(())
+    } else {
+        Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ApiError::new(
+                "ADAPTER_NOT_SUPPORTED",
+                "This operation requires a markdown adapter",
+            )),
+        ))
+    }
+}
+
+/// Try to resolve a spec id to a `README.md` path under the project's specs
+/// directory. Used by markdown-specific handlers (raw read/write, sub-spec
+/// access) that operate on files directly.
+pub(super) fn resolve_markdown_spec_path(specs_dir: &FsPath, spec_id: &str) -> Option<PathBuf> {
+    let direct = specs_dir.join(spec_id).join("README.md");
+    if direct.exists() {
+        return Some(direct);
+    }
+
+    let entries = std::fs::read_dir(specs_dir).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name.contains(spec_id) || spec_id.contains(name) {
+            let readme = path.join("README.md");
+            if readme.exists() {
+                return Some(readme);
+            }
+        }
+    }
+    None
 }
 
 pub(super) fn hash_raw_content(content: &str) -> String {

--- a/rust/leanspec-http/src/handlers/specs/read.rs
+++ b/rust/leanspec-http/src/handlers/specs/read.rs
@@ -2,43 +2,88 @@
 
 #![allow(clippy::result_large_err)]
 
+use std::collections::{HashMap, HashSet};
+use std::fs;
+
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::Json;
-use std::fs;
 
-use leanspec_core::{
-    search_specs_with_options, DependencyGraph, SearchOptions, SpecFilterOptions,
-    SpecHierarchyNode, SpecStatus,
-};
+use leanspec_core::adapters::ListFilter;
+use leanspec_core::{semantic, SpecDoc, SpecSchema};
 
 use crate::error::{ApiError, ApiResult};
 use crate::state::AppState;
 
 use crate::types::{
-    ListSpecsQuery, ListSpecsResponse, SearchRequest, SearchResponse, SpecDetail, SpecRawResponse,
-    SpecSummary,
+    HierarchyNode, ListSpecsQuery, ListSpecsResponse, SearchRequest, SearchResponse, SpecDetail,
+    SpecRawResponse, SpecRelationships, SpecSummary,
 };
 
-use super::helpers::{detect_sub_specs, get_spec_loader, hash_raw_content};
+use super::helpers::{
+    adapter_error, detect_sub_specs, get_adapter_and_project, hash_raw_content,
+    require_markdown_adapter, resolve_markdown_spec_path,
+};
 
-fn parse_status_filter(
-    status: &Option<String>,
-) -> Result<Option<Vec<SpecStatus>>, (StatusCode, Json<ApiError>)> {
-    let parsed = status.as_ref().map(|s| {
+const LINK_PARENT: &str = "parent";
+const LINK_DEPENDS_ON: &str = "depends_on";
+
+fn parse_csv_filter(value: &Option<String>) -> Option<Vec<String>> {
+    value.as_ref().map(|s| {
         s.split(',')
-            .filter_map(|s| s.parse().ok())
-            .collect::<Vec<_>>()
-    });
+            .map(|part| part.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    })
+}
 
-    if status.is_some() && parsed.as_ref().map_or(true, |v| v.is_empty()) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ApiError::invalid_request("Invalid status filter")),
-        ));
+fn build_list_filter(query: &ListSpecsQuery, schema: &SpecSchema) -> ListFilter {
+    let mut fields: HashMap<String, Vec<String>> = HashMap::new();
+
+    if let Some(values) = parse_csv_filter(&query.status) {
+        if !values.is_empty() {
+            if let Some(key) = schema.key_for_semantic(semantic::STATUS) {
+                fields.insert(key.to_string(), values);
+            }
+        }
+    }
+    if let Some(values) = parse_csv_filter(&query.priority) {
+        if !values.is_empty() {
+            if let Some(key) = schema.key_for_semantic(semantic::PRIORITY) {
+                fields.insert(key.to_string(), values);
+            }
+        }
+    }
+    if let Some(values) = parse_csv_filter(&query.tags) {
+        if !values.is_empty() {
+            if let Some(key) = schema.key_for_semantic(semantic::TAGS) {
+                fields.insert(key.to_string(), values);
+            }
+        }
+    }
+    if let Some(assignee) = query.assignee.as_ref().filter(|s| !s.is_empty()) {
+        if let Some(key) = schema.key_for_semantic(semantic::ASSIGNEE) {
+            fields.insert(key.to_string(), vec![assignee.clone()]);
+        }
     }
 
-    Ok(parsed)
+    // Status filter explicitly "archived" implies include_archived; otherwise
+    // the user's archived specs are filtered out by the adapter list pass.
+    let include_archived = fields
+        .get(
+            schema
+                .key_for_semantic(semantic::STATUS)
+                .unwrap_or("status"),
+        )
+        .map(|values| values.iter().any(|v| v == "archived"))
+        .unwrap_or(false);
+
+    ListFilter {
+        fields,
+        text: None,
+        include_archived,
+        raw: None,
+    }
 }
 
 fn apply_pagination<T>(items: Vec<T>, offset: Option<usize>, limit: Option<usize>) -> Vec<T> {
@@ -77,7 +122,58 @@ fn next_cursor(total: usize, offset: usize, limit: Option<usize>) -> Option<Stri
     }
 }
 
-fn sort_hierarchy_nodes(nodes: &mut [crate::types::HierarchyNode]) {
+/// Build child→parent and parent→children maps from the document set's links.
+fn build_relationship_index(docs: &[SpecDoc]) -> RelationshipIndex {
+    let mut parent_by_child: HashMap<String, String> = HashMap::new();
+    let mut children_by_parent: HashMap<String, Vec<String>> = HashMap::new();
+    let mut required_by: HashMap<String, Vec<String>> = HashMap::new();
+
+    for doc in docs {
+        for link in &doc.links {
+            match link.link_type.as_str() {
+                LINK_PARENT => {
+                    parent_by_child.insert(doc.id.clone(), link.target_id.clone());
+                    children_by_parent
+                        .entry(link.target_id.clone())
+                        .or_default()
+                        .push(doc.id.clone());
+                }
+                LINK_DEPENDS_ON => {
+                    if link.target_id != doc.id {
+                        required_by
+                            .entry(link.target_id.clone())
+                            .or_default()
+                            .push(doc.id.clone());
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    for list in children_by_parent.values_mut() {
+        list.sort();
+        list.dedup();
+    }
+    for list in required_by.values_mut() {
+        list.sort();
+        list.dedup();
+    }
+
+    RelationshipIndex {
+        parent_by_child,
+        children_by_parent,
+        required_by,
+    }
+}
+
+struct RelationshipIndex {
+    parent_by_child: HashMap<String, String>,
+    children_by_parent: HashMap<String, Vec<String>>,
+    required_by: HashMap<String, Vec<String>>,
+}
+
+fn sort_hierarchy_nodes(nodes: &mut [HierarchyNode]) {
     nodes.sort_by(|a, b| match (b.spec.spec_number, a.spec.spec_number) {
         (Some(bn), Some(an)) => bn.cmp(&an),
         (Some(_), None) => std::cmp::Ordering::Less,
@@ -90,46 +186,74 @@ fn sort_hierarchy_nodes(nodes: &mut [crate::types::HierarchyNode]) {
     }
 }
 
-fn build_hierarchy_from_cached_tree(
-    tree: &[SpecHierarchyNode],
-    filtered_specs: &[crate::types::SpecSummary],
-) -> Vec<crate::types::HierarchyNode> {
-    use std::collections::{HashMap, HashSet};
-
-    let allowed: HashSet<String> = filtered_specs.iter().map(|s| s.spec_name.clone()).collect();
-    let spec_map: HashMap<String, crate::types::SpecSummary> = filtered_specs
+fn build_hierarchy(summaries: &[SpecSummary], index: &RelationshipIndex) -> Vec<HierarchyNode> {
+    let summaries_by_id: HashMap<String, SpecSummary> = summaries
         .iter()
         .map(|s| (s.spec_name.clone(), s.clone()))
         .collect();
+    let allowed: HashSet<String> = summaries_by_id.keys().cloned().collect();
 
-    fn filter_nodes(
-        nodes: &[SpecHierarchyNode],
+    fn walk(
+        id: &str,
         allowed: &HashSet<String>,
-        spec_map: &HashMap<String, crate::types::SpecSummary>,
-    ) -> Vec<crate::types::HierarchyNode> {
+        summaries_by_id: &HashMap<String, SpecSummary>,
+        children_by_parent: &HashMap<String, Vec<String>>,
+    ) -> Vec<HierarchyNode> {
         let mut out = Vec::new();
-
-        for node in nodes {
-            let child_nodes = filter_nodes(&node.child_nodes, allowed, spec_map);
-            if allowed.contains(&node.path) {
-                if let Some(spec) = spec_map.get(&node.path) {
-                    out.push(crate::types::HierarchyNode {
+        let children = children_by_parent.get(id).cloned().unwrap_or_default();
+        for child in children {
+            let descendants = walk(&child, allowed, summaries_by_id, children_by_parent);
+            if allowed.contains(&child) {
+                if let Some(spec) = summaries_by_id.get(&child) {
+                    out.push(HierarchyNode {
                         spec: spec.clone(),
-                        child_nodes,
+                        child_nodes: descendants,
                     });
                 }
             } else {
-                // Promote matching descendants when the current node is filtered out.
-                out.extend(child_nodes);
+                out.extend(descendants);
             }
         }
-
         out
     }
 
-    let mut hierarchy = filter_nodes(tree, &allowed, &spec_map);
-    sort_hierarchy_nodes(&mut hierarchy);
-    hierarchy
+    let mut roots: Vec<HierarchyNode> = Vec::new();
+    for summary in summaries {
+        let id = &summary.spec_name;
+        let parent_in_set = index
+            .parent_by_child
+            .get(id)
+            .map(|p| allowed.contains(p))
+            .unwrap_or(false);
+        if parent_in_set {
+            continue;
+        }
+        let children = walk(id, &allowed, &summaries_by_id, &index.children_by_parent);
+        roots.push(HierarchyNode {
+            spec: summary.clone(),
+            child_nodes: children,
+        });
+    }
+
+    sort_hierarchy_nodes(&mut roots);
+    roots
+}
+
+fn doc_url_or_default(doc: &SpecDoc) -> String {
+    doc.url.clone().unwrap_or_default()
+}
+
+fn enrich_summary_from_doc(summary: &mut SpecSummary, doc: &SpecDoc, index: &RelationshipIndex) {
+    summary.children = index
+        .children_by_parent
+        .get(&doc.id)
+        .cloned()
+        .unwrap_or_default();
+    summary.required_by = index.required_by.get(&doc.id).cloned().unwrap_or_default();
+    summary.relationships = Some(SpecRelationships {
+        depends_on: summary.depends_on.clone(),
+        required_by: Some(summary.required_by.clone()),
+    });
 }
 
 /// GET /api/projects/:projectId/specs - List specs for a project
@@ -140,46 +264,24 @@ pub async fn list_project_specs(
 ) -> ApiResult<Json<ListSpecsResponse>> {
     let (page_offset, page_limit) = resolve_pagination(&query)?;
 
-    let (loader, project) = get_spec_loader(&state, &project_id).await?;
+    let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
+    let schema = adapter.schema();
 
-    let all_specs = loader.load_all_metadata().map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
-    let relationship_index = loader.load_relationship_index().map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
-    let cached_tree = loader.load_hierarchy_tree().map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
+    let filter = build_list_filter(&query, schema);
+    let docs = adapter.list(&filter).map_err(adapter_error)?;
 
-    let status_filter = parse_status_filter(&query.status)?;
+    let index = build_relationship_index(&docs);
 
-    // Apply filters
-    let filters = SpecFilterOptions {
-        status: status_filter,
-        priority: query
-            .priority
-            .map(|s| s.split(',').filter_map(|s| s.parse().ok()).collect()),
-        tags: query
-            .tags
-            .map(|s| s.split(',').map(|s| s.to_string()).collect()),
-        assignee: query.assignee,
-        search: None,
-    };
-
-    let mut filtered_specs: Vec<SpecSummary> = all_specs
+    let mut filtered_specs: Vec<SpecSummary> = docs
         .iter()
-        .filter(|s| filters.matches(s))
-        .map(|s| SpecSummary::from_without_computed(s).with_project_id(&project.id))
+        .map(|doc| {
+            let mut summary = SpecSummary::from_doc(doc, schema).with_project_id(&project.id);
+            // Markdown adapter populates url=None; for filesystem URL we leave
+            // the file_path empty and rely on the adapter for raw access.
+            summary.file_path = doc_url_or_default(doc);
+            enrich_summary_from_doc(&mut summary, doc, &index);
+            summary
+        })
         .collect();
 
     filtered_specs.sort_by(|a, b| {
@@ -187,28 +289,6 @@ pub async fn list_project_specs(
             .cmp(&a.spec_number)
             .then_with(|| b.spec_name.cmp(&a.spec_name))
     });
-
-    let filtered_specs: Vec<SpecSummary> = filtered_specs
-        .into_iter()
-        .map(|mut summary| {
-            let required_by = relationship_index
-                .required_by
-                .get(&summary.spec_name)
-                .cloned()
-                .unwrap_or_default();
-            summary.required_by = required_by.clone();
-            summary.children = relationship_index
-                .children_by_parent
-                .get(&summary.spec_name)
-                .cloned()
-                .unwrap_or_default();
-            summary.relationships = Some(crate::types::SpecRelationships {
-                depends_on: summary.depends_on.clone(),
-                required_by: Some(required_by),
-            });
-            summary
-        })
-        .collect();
 
     let total = filtered_specs.len();
     let hierarchy_requested = query.hierarchy.unwrap_or(false);
@@ -223,12 +303,8 @@ pub async fn list_project_specs(
         next_cursor(total, page_offset, page_limit)
     };
 
-    // Build hierarchy if requested - computed server-side for performance
     let hierarchy = if hierarchy_requested {
-        Some(build_hierarchy_from_cached_tree(
-            &cached_tree,
-            &filtered_specs,
-        ))
+        Some(build_hierarchy(&filtered_specs, &index))
     } else {
         None
     };
@@ -247,53 +323,43 @@ pub async fn get_project_spec(
     State(state): State<AppState>,
     Path((project_id, spec_id)): Path<(String, String)>,
 ) -> ApiResult<Json<SpecDetail>> {
-    let (loader, project) = get_spec_loader(&state, &project_id).await?;
+    let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
+    let schema = adapter.schema();
 
-    let spec = loader.load(&spec_id).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
+    let doc = adapter.get(&spec_id).map_err(adapter_error)?;
 
-    let spec = spec.ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ApiError::spec_not_found(&spec_id)),
-        )
-    })?;
+    let mut detail = SpecDetail::from_doc(&doc, schema).with_project_id(project.id.clone());
 
-    // Get dependency graph to compute required_by
-    let all_specs = loader.load_all().unwrap_or_default();
-    let dep_graph = DependencyGraph::new(&all_specs);
+    // Compute required_by/children from the full document set.
+    let all_docs = adapter
+        .list(&ListFilter {
+            include_archived: true,
+            ..Default::default()
+        })
+        .map_err(adapter_error)?;
+    let index = build_relationship_index(&all_docs);
 
-    let mut detail = SpecDetail::from(&spec).with_project_id(project.id.clone());
+    let required_by = index.required_by.get(&doc.id).cloned().unwrap_or_default();
+    detail.required_by = required_by.clone();
+    detail.relationships = Some(SpecRelationships {
+        depends_on: detail.depends_on.clone(),
+        required_by: Some(required_by),
+    });
+    detail.children = index
+        .children_by_parent
+        .get(&doc.id)
+        .cloned()
+        .unwrap_or_default();
 
-    // Compute required_by (filter out self-references)
-    if let Some(complete) = dep_graph.get_complete_graph(&spec.path) {
-        let required_by: Vec<String> = complete
-            .required_by
-            .iter()
-            .filter(|s| s.path != spec.path) // Prevent self-reference bug
-            .map(|s| s.path.clone())
-            .collect();
-        detail.required_by = required_by.clone();
-        detail.relationships = Some(crate::types::SpecRelationships {
-            depends_on: detail.depends_on.clone(),
-            required_by: Some(required_by),
-        });
-    }
-
-    let children: Vec<String> = all_specs
-        .iter()
-        .filter(|s| s.frontmatter.parent.as_deref() == Some(spec.path.as_str()))
-        .map(|s| s.path.clone())
-        .collect();
-    detail.children = children;
-
-    let sub_specs = detect_sub_specs(&detail.file_path);
-    if !sub_specs.is_empty() {
-        detail.sub_specs = Some(sub_specs);
+    // Markdown adapter exposes the on-disk path; populate it for the UI.
+    if adapter.capabilities().name == "markdown" {
+        if let Some(path) = resolve_markdown_spec_path(&project.specs_dir, &spec_id) {
+            detail = detail.with_file_path(path.to_string_lossy().to_string());
+            let sub_specs = detect_sub_specs(&detail.file_path);
+            if !sub_specs.is_empty() {
+                detail.sub_specs = Some(sub_specs);
+            }
+        }
     }
 
     Ok(Json(detail))
@@ -304,22 +370,20 @@ pub async fn get_project_spec_raw(
     State(state): State<AppState>,
     Path((project_id, spec_id)): Path<(String, String)>,
 ) -> ApiResult<Json<SpecRawResponse>> {
-    let (loader, _project) = get_spec_loader(&state, &project_id).await?;
-    let spec = loader.load(&spec_id).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
+    let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
+    require_markdown_adapter(adapter.as_ref())?;
 
-    let spec = spec.ok_or_else(|| {
+    // Surface a 404 if the spec doesn't exist at all.
+    adapter.get(&spec_id).map_err(adapter_error)?;
+
+    let file_path = resolve_markdown_spec_path(&project.specs_dir, &spec_id).ok_or_else(|| {
         (
             StatusCode::NOT_FOUND,
             Json(ApiError::spec_not_found(&spec_id)),
         )
     })?;
 
-    let content = fs::read_to_string(&spec.file_path).map_err(|e| {
+    let content = fs::read_to_string(&file_path).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiError::internal_error(&e.to_string())),
@@ -330,7 +394,7 @@ pub async fn get_project_spec_raw(
     Ok(Json(SpecRawResponse {
         content,
         content_hash,
-        file_path: spec.file_path.to_string_lossy().to_string(),
+        file_path: file_path.to_string_lossy().to_string(),
     }))
 }
 
@@ -346,22 +410,20 @@ pub async fn get_project_subspec_raw(
         ));
     }
 
-    let (loader, _project) = get_spec_loader(&state, &project_id).await?;
-    let spec = loader.load(&spec_id).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
+    let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
+    require_markdown_adapter(adapter.as_ref())?;
 
-    let spec = spec.ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ApiError::spec_not_found(&spec_id)),
-        )
-    })?;
+    adapter.get(&spec_id).map_err(adapter_error)?;
 
-    let parent_dir = spec.file_path.parent().ok_or_else(|| {
+    let spec_readme =
+        resolve_markdown_spec_path(&project.specs_dir, &spec_id).ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ApiError::spec_not_found(&spec_id)),
+            )
+        })?;
+
+    let parent_dir = spec_readme.parent().ok_or_else(|| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiError::internal_error("Missing spec directory")),
@@ -396,49 +458,53 @@ pub async fn search_project_specs(
     Path(project_id): Path<String>,
     Json(req): Json<SearchRequest>,
 ) -> ApiResult<Json<SearchResponse>> {
-    let (loader, project) = get_spec_loader(&state, &project_id).await?;
+    let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
+    let schema = adapter.schema();
 
-    let all_specs = loader.load_all().map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
-
-    // Build enriched query by appending UI filter fields to the search query.
-    // This lets the core search engine handle field filters (status:, priority:, tag:)
-    // alongside the user's text query with boolean operators, fuzzy matching, etc.
-    let mut enriched_query = req.query.clone();
-    if let Some(ref filters) = req.filters {
-        if let Some(ref status) = filters.status {
-            enriched_query.push_str(&format!(" status:{}", status));
+    // Build a filter that combines free-text with field constraints from the
+    // structured request body. The adapter's list pass handles equality on
+    // status/priority/tags so the UI doesn't have to re-implement filtering.
+    let mut fields: HashMap<String, Vec<String>> = HashMap::new();
+    if let Some(filters) = req.filters.as_ref() {
+        if let Some(status) = filters.status.as_ref().filter(|s| !s.is_empty()) {
+            if let Some(key) = schema.key_for_semantic(semantic::STATUS) {
+                fields.insert(key.to_string(), vec![status.clone()]);
+            }
         }
-        if let Some(ref priority) = filters.priority {
-            enriched_query.push_str(&format!(" priority:{}", priority));
+        if let Some(priority) = filters.priority.as_ref().filter(|s| !s.is_empty()) {
+            if let Some(key) = schema.key_for_semantic(semantic::PRIORITY) {
+                fields.insert(key.to_string(), vec![priority.clone()]);
+            }
         }
-        if let Some(ref tags) = filters.tags {
-            for tag in tags {
-                enriched_query.push_str(&format!(" tag:{}", tag));
+        if let Some(tags) = filters.tags.as_ref().filter(|t| !t.is_empty()) {
+            if let Some(key) = schema.key_for_semantic(semantic::TAGS) {
+                fields.insert(key.to_string(), tags.clone());
             }
         }
     }
 
-    // Use the core search engine for advanced query parsing, fuzzy matching,
-    // boolean operators, field filters, and relevance scoring.
-    let search_results =
-        search_specs_with_options(&all_specs, &enriched_query, SearchOptions::new());
+    let text = if req.query.trim().is_empty() {
+        None
+    } else {
+        Some(req.query.clone())
+    };
 
-    // Map core SearchResults back to SpecSummary objects.
-    // Build a lookup from path → SpecInfo for efficient mapping.
-    let spec_map: std::collections::HashMap<&str, &leanspec_core::SpecInfo> =
-        all_specs.iter().map(|s| (s.path.as_str(), s)).collect();
+    let filter = ListFilter {
+        fields,
+        text,
+        include_archived: false,
+        raw: None,
+    };
 
-    let results: Vec<SpecSummary> = search_results
+    let docs = adapter.list(&filter).map_err(adapter_error)?;
+
+    let results: Vec<SpecSummary> = docs
         .iter()
-        .filter_map(|sr| {
-            spec_map
-                .get(sr.path.as_str())
-                .map(|s| SpecSummary::from(*s).with_project_id(&project.id))
+        .map(|doc| {
+            let mut summary =
+                SpecSummary::from_doc_with_tokens(doc, schema).with_project_id(&project.id);
+            summary.file_path = doc_url_or_default(doc);
+            summary
         })
         .collect();
 

--- a/rust/leanspec-http/src/handlers/specs/read.rs
+++ b/rust/leanspec-http/src/handlers/specs/read.rs
@@ -198,11 +198,24 @@ fn build_hierarchy(summaries: &[SpecSummary], index: &RelationshipIndex) -> Vec<
         allowed: &HashSet<String>,
         summaries_by_id: &HashMap<String, SpecSummary>,
         children_by_parent: &HashMap<String, Vec<String>>,
+        visited: &mut HashSet<String>,
     ) -> Vec<HierarchyNode> {
+        if !visited.insert(id.to_string()) {
+            // Cycle detected — stop recursing. The first visit owns the
+            // subtree so downstream renderers still see the spec exactly
+            // once.
+            return Vec::new();
+        }
         let mut out = Vec::new();
         let children = children_by_parent.get(id).cloned().unwrap_or_default();
         for child in children {
-            let descendants = walk(&child, allowed, summaries_by_id, children_by_parent);
+            let descendants = walk(
+                &child,
+                allowed,
+                summaries_by_id,
+                children_by_parent,
+                visited,
+            );
             if allowed.contains(&child) {
                 if let Some(spec) = summaries_by_id.get(&child) {
                     out.push(HierarchyNode {
@@ -218,6 +231,7 @@ fn build_hierarchy(summaries: &[SpecSummary], index: &RelationshipIndex) -> Vec<
     }
 
     let mut roots: Vec<HierarchyNode> = Vec::new();
+    let mut visited: HashSet<String> = HashSet::new();
     for summary in summaries {
         let id = &summary.spec_name;
         let parent_in_set = index
@@ -228,7 +242,16 @@ fn build_hierarchy(summaries: &[SpecSummary], index: &RelationshipIndex) -> Vec<
         if parent_in_set {
             continue;
         }
-        let children = walk(id, &allowed, &summaries_by_id, &index.children_by_parent);
+        if !visited.insert(id.clone()) {
+            continue;
+        }
+        let children = walk(
+            id,
+            &allowed,
+            &summaries_by_id,
+            &index.children_by_parent,
+            &mut visited,
+        );
         roots.push(HierarchyNode {
             spec: summary.clone(),
             child_nodes: children,
@@ -239,8 +262,30 @@ fn build_hierarchy(summaries: &[SpecSummary], index: &RelationshipIndex) -> Vec<
     roots
 }
 
-fn doc_url_or_default(doc: &SpecDoc) -> String {
-    doc.url.clone().unwrap_or_default()
+/// Populate the response `file_path` from the adapter or, for markdown
+/// projects, from the on-disk `README.md` path so list/search responses
+/// expose the same path the UI used to receive.
+fn populate_file_path(
+    summary_file_path: &mut String,
+    doc: &SpecDoc,
+    adapter: &dyn leanspec_core::Adapter,
+    specs_dir: &std::path::Path,
+) {
+    if let Some(url) = doc.url.as_ref() {
+        if !url.is_empty() {
+            *summary_file_path = url.clone();
+            return;
+        }
+    }
+
+    if adapter.capabilities().name == "markdown" {
+        if let Some(path) = super::helpers::resolve_markdown_spec_path(specs_dir, &doc.id) {
+            *summary_file_path = path.to_string_lossy().to_string();
+            return;
+        }
+    }
+
+    *summary_file_path = String::new();
 }
 
 fn enrich_summary_from_doc(summary: &mut SpecSummary, doc: &SpecDoc, index: &RelationshipIndex) {
@@ -276,9 +321,12 @@ pub async fn list_project_specs(
         .iter()
         .map(|doc| {
             let mut summary = SpecSummary::from_doc(doc, schema).with_project_id(&project.id);
-            // Markdown adapter populates url=None; for filesystem URL we leave
-            // the file_path empty and rely on the adapter for raw access.
-            summary.file_path = doc_url_or_default(doc);
+            populate_file_path(
+                &mut summary.file_path,
+                doc,
+                adapter.as_ref(),
+                &project.specs_dir,
+            );
             enrich_summary_from_doc(&mut summary, doc, &index);
             summary
         })
@@ -503,7 +551,12 @@ pub async fn search_project_specs(
         .map(|doc| {
             let mut summary =
                 SpecSummary::from_doc_with_tokens(doc, schema).with_project_id(&project.id);
-            summary.file_path = doc_url_or_default(doc);
+            populate_file_path(
+                &mut summary.file_path,
+                doc,
+                adapter.as_ref(),
+                &project.specs_dir,
+            );
             summary
         })
         .collect();
@@ -516,4 +569,80 @@ pub async fn search_project_specs(
         query: req.query,
         project_id: Some(project.id),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leanspec_core::ItemLink;
+
+    fn dummy_summary(id: &str) -> SpecSummary {
+        SpecSummary {
+            project_id: None,
+            id: id.to_string(),
+            spec_number: id.split('-').next().and_then(|s| s.parse().ok()),
+            spec_name: id.to_string(),
+            title: Some(id.to_string()),
+            status: "planned".into(),
+            priority: None,
+            tags: vec![],
+            assignee: None,
+            created_at: None,
+            updated_at: None,
+            completed_at: None,
+            file_path: String::new(),
+            depends_on: vec![],
+            parent: None,
+            children: vec![],
+            required_by: vec![],
+            content_hash: None,
+            token_count: None,
+            token_status: None,
+            validation_status: None,
+            relationships: None,
+        }
+    }
+
+    fn dummy_doc(id: &str, parent: Option<&str>) -> SpecDoc {
+        let mut links = vec![];
+        if let Some(p) = parent {
+            links.push(ItemLink {
+                link_type: "parent".into(),
+                target_id: p.to_string(),
+                target_title: None,
+            });
+        }
+        SpecDoc {
+            id: id.to_string(),
+            title: id.to_string(),
+            schema_id: "leanspec:markdown".into(),
+            fields: std::collections::HashMap::new(),
+            links,
+            created_at: None,
+            updated_at: None,
+            url: None,
+            raw: None,
+        }
+    }
+
+    #[test]
+    fn build_hierarchy_handles_parent_cycle_without_recursion() {
+        // A is parent of B, B is parent of A — pathological but possible if a
+        // user hand-edits spec frontmatter. Previously this would recurse
+        // forever; now it must terminate and return each spec at most once.
+        let docs = vec![
+            dummy_doc("001-a", Some("002-b")),
+            dummy_doc("002-b", Some("001-a")),
+        ];
+        let index = build_relationship_index(&docs);
+
+        let summaries = vec![dummy_summary("001-a"), dummy_summary("002-b")];
+        let hierarchy = build_hierarchy(&summaries, &index);
+
+        fn count_nodes(nodes: &[HierarchyNode]) -> usize {
+            nodes.iter().map(|n| 1 + count_nodes(&n.child_nodes)).sum()
+        }
+        // Each spec appears at most once across the whole tree.
+        assert!(count_nodes(&hierarchy) <= 2);
+    }
 }

--- a/rust/leanspec-http/src/handlers/specs/write.rs
+++ b/rust/leanspec-http/src/handlers/specs/write.rs
@@ -38,7 +38,7 @@ use crate::types::{
 };
 
 use super::helpers::{
-    adapter_error, get_adapter_and_project, hash_raw_content, load_project_config,
+    adapter_error, get_adapter_and_project, hash_raw_content, invalid_spec_id, load_project_config,
     require_markdown_adapter, resolve_markdown_spec_path,
 };
 
@@ -137,6 +137,15 @@ pub async fn create_project_spec(
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ApiError::invalid_request("Spec name is required")),
+        ));
+    }
+    // Refuse names that could escape the project's specs directory.
+    if invalid_spec_id(spec_name) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ApiError::invalid_request(
+                "Spec name must not contain path separators, '..', or absolute paths",
+            )),
         ));
     }
 

--- a/rust/leanspec-http/src/handlers/specs/write.rs
+++ b/rust/leanspec-http/src/handlers/specs/write.rs
@@ -1,24 +1,31 @@
 //! Spec write handlers: create, update, toggle, batch metadata
+//!
+//! The HTTP read path is adapter-driven (see [`super::read`] and spec #261).
+//! Write handlers in this module use the adapter API for create/update/delete
+//! and the markdown adapter's typed helpers (`SpecInfo`,
+//! `CompletionVerifier`) for markdown-specific behaviour like umbrella
+//! completion checks and template rendering. Full migration to a
+//! schema-driven write path lives in spec #262.
 
 #![allow(clippy::result_large_err)]
 
-use axum::extract::{Path, State};
-use axum::http::StatusCode;
-use axum::Json;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path as FsPath;
 use std::sync::{LazyLock, RwLock};
 
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+
+use leanspec_core::adapters::markdown::{SpecInfo, SpecStatus};
+use leanspec_core::adapters::ListFilter;
 use leanspec_core::io::hash_content;
-use leanspec_core::spec_ops::{
-    apply_checklist_toggles, rebuild_content, split_frontmatter, ChecklistToggle,
-};
 use leanspec_core::{
-    global_frontmatter_validator, global_structure_validator, global_token_count_validator,
-    global_token_counter, CompletionVerifier, FrontmatterParser,
-    MetadataUpdate as CoreMetadataUpdate, SpecArchiver, SpecStatus, SpecWriter, TemplateLoader,
-    TokenStatus, ValidationResult,
+    apply_checklist_toggles, global_frontmatter_validator, global_structure_validator,
+    global_token_count_validator, global_token_counter, rebuild_content, semantic,
+    split_frontmatter, ChecklistToggle, CompletionVerifier, FieldValue, FrontmatterParser, SpecDoc,
+    SpecSchema, TemplateLoader, TokenStatus, UpdateRequest, ValidationResult,
 };
 
 use crate::error::{ApiError, ApiResult};
@@ -26,14 +33,16 @@ use crate::state::AppState;
 
 use crate::types::{
     BatchMetadataRequest, BatchMetadataResponse, ChecklistToggleRequest, ChecklistToggleResponse,
-    ChecklistToggledResult, CreateSpecRequest, MetadataUpdate, SpecDetail, SpecMetadata,
-    SpecRawResponse, SpecRawUpdateRequest,
+    ChecklistToggledResult, CreateSpecRequest, FrontmatterResponse, MetadataUpdate, SpecDetail,
+    SpecMetadata, SpecRawResponse, SpecRawUpdateRequest, UpdateMetadataResponse,
 };
 
-use super::helpers::{get_spec_loader, hash_raw_content, load_project_config};
+use super::helpers::{
+    adapter_error, get_adapter_and_project, hash_raw_content, load_project_config,
+    require_markdown_adapter, resolve_markdown_spec_path,
+};
 
 // In-process cache for expensive batch metadata computation.
-// Keyed by project/spec and invalidated implicitly when content hash changes.
 static BATCH_METADATA_CACHE: LazyLock<RwLock<HashMap<String, (String, SpecMetadata)>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
@@ -46,7 +55,6 @@ fn render_template(template: &str, name: &str, status: &str, priority: &str, dat
 }
 
 /// Check if draft status is enabled in project config.
-/// Uses a local struct since leanspec_core::LeanSpecConfig doesn't have draft_status.
 fn is_draft_status_enabled(project_path: &FsPath) -> bool {
     #[derive(serde::Deserialize)]
     #[serde(rename_all = "camelCase")]
@@ -70,19 +78,49 @@ fn is_draft_status_enabled(project_path: &FsPath) -> bool {
         .unwrap_or(false)
 }
 
-fn rebuild_with_frontmatter(
-    frontmatter: &leanspec_core::SpecFrontmatter,
-    body: &str,
-) -> Result<String, (StatusCode, Json<ApiError>)> {
-    let yaml = serde_yaml::to_string(frontmatter).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
+fn doc_field_str<'a>(doc: &'a SpecDoc, key: &str) -> Option<&'a str> {
+    doc.fields.get(key)?.as_str()
+}
 
-    let trimmed_body = body.trim_start_matches('\n');
-    Ok(format!("---\n{}---\n{}", yaml, trimmed_body))
+fn semantic_value<'a>(doc: &'a SpecDoc, schema: &SpecSchema, sem: &str) -> Option<&'a str> {
+    doc_field_str(doc, schema.key_for_semantic(sem)?)
+}
+
+fn validate_enum_value(
+    schema: &SpecSchema,
+    field_key: &str,
+    value: &str,
+) -> Result<(), (StatusCode, Json<ApiError>)> {
+    use leanspec_core::FieldKind;
+
+    let Some(field) = schema.field(field_key) else {
+        return Ok(());
+    };
+    let FieldKind::Enum {
+        options,
+        allow_custom,
+        ..
+    } = &field.kind
+    else {
+        return Ok(());
+    };
+
+    if *allow_custom || options.is_empty() {
+        return Ok(());
+    }
+
+    if options.iter().any(|o| o.value == value) {
+        Ok(())
+    } else {
+        let valid: Vec<String> = options.iter().map(|o| o.value.clone()).collect();
+        Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(
+                ApiError::invalid_request(&format!("Invalid value for {}: '{}'", field_key, value))
+                    .with_details(serde_json::json!({ "validValues": valid })),
+            ),
+        ))
+    }
 }
 
 /// POST /api/projects/:projectId/specs - Create a spec in a project
@@ -91,7 +129,9 @@ pub async fn create_project_spec(
     Path(project_id): Path<String>,
     Json(request): Json<CreateSpecRequest>,
 ) -> ApiResult<Json<SpecDetail>> {
-    let (loader, project) = get_spec_loader(&state, &project_id).await?;
+    let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
+    require_markdown_adapter(adapter.as_ref())?;
+
     let spec_name = request.name.trim();
     if spec_name.is_empty() {
         return Err((
@@ -156,34 +196,50 @@ pub async fn create_project_spec(
     if let Ok(parsed) = status.parse() {
         frontmatter.status = parsed;
     }
-
     if let Ok(parsed) = priority.parse() {
         frontmatter.priority = Some(parsed);
     }
-
     if let Some(tags) = request.tags.clone() {
         frontmatter.tags = tags;
     }
-
     if let Some(assignee) = request.assignee.clone() {
         frontmatter.assignee = Some(assignee);
     }
-
     if let Some(depends_on) = request.depends_on.clone() {
         frontmatter.depends_on = depends_on;
     }
 
-    let full_content = rebuild_with_frontmatter(&frontmatter, &body)?;
-    let created = loader
-        .create_spec(spec_name, &title, &full_content)
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ApiError::internal_error(&e.to_string())),
-            )
-        })?;
+    let yaml = serde_yaml::to_string(&frontmatter).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiError::internal_error(&e.to_string())),
+        )
+    })?;
+    let trimmed_body = body.trim_start_matches('\n');
+    let full_content = format!("---\n{}---\n{}", yaml, trimmed_body);
 
-    Ok(Json(SpecDetail::from(&created)))
+    // Write the spec directly through the filesystem (markdown adapter
+    // semantics) and then re-fetch it via the adapter for the response.
+    fs::create_dir_all(&spec_dir).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiError::internal_error(&e.to_string())),
+        )
+    })?;
+    fs::write(spec_dir.join("README.md"), &full_content).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiError::internal_error(&e.to_string())),
+        )
+    })?;
+
+    let doc = adapter.get(spec_name).map_err(adapter_error)?;
+    let mut detail =
+        SpecDetail::from_doc(&doc, adapter.schema()).with_project_id(project.id.clone());
+    if let Some(path) = resolve_markdown_spec_path(&project.specs_dir, spec_name) {
+        detail = detail.with_file_path(path.to_string_lossy().to_string());
+    }
+    Ok(Json(detail))
 }
 
 /// PATCH /api/projects/:projectId/specs/:spec/raw - Update raw spec content
@@ -192,22 +248,19 @@ pub async fn update_project_spec_raw(
     Path((project_id, spec_id)): Path<(String, String)>,
     Json(request): Json<SpecRawUpdateRequest>,
 ) -> ApiResult<Json<SpecRawResponse>> {
-    let (loader, _project) = get_spec_loader(&state, &project_id).await?;
-    let spec = loader.load(&spec_id).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
+    let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
+    require_markdown_adapter(adapter.as_ref())?;
 
-    let spec = spec.ok_or_else(|| {
+    adapter.get(&spec_id).map_err(adapter_error)?;
+
+    let file_path = resolve_markdown_spec_path(&project.specs_dir, &spec_id).ok_or_else(|| {
         (
             StatusCode::NOT_FOUND,
             Json(ApiError::spec_not_found(&spec_id)),
         )
     })?;
 
-    let current = fs::read_to_string(&spec.file_path).map_err(|e| {
+    let current = fs::read_to_string(&file_path).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiError::internal_error(&e.to_string())),
@@ -224,20 +277,20 @@ pub async fn update_project_spec_raw(
         }
     }
 
-    // Write directly to the resolved file_path (spec.file_path) instead of
-    // calling update_spec(&spec_id, ..) which doesn't do fuzzy path resolution.
-    fs::write(&spec.file_path, &request.content).map_err(|e| {
+    fs::write(&file_path, &request.content).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiError::internal_error(&e.to_string())),
         )
     })?;
 
+    invalidate_markdown_cache(&project.specs_dir, &file_path);
+
     let new_hash = hash_raw_content(&request.content);
     Ok(Json(SpecRawResponse {
         content: request.content,
         content_hash: new_hash,
-        file_path: spec.file_path.to_string_lossy().to_string(),
+        file_path: file_path.to_string_lossy().to_string(),
     }))
 }
 
@@ -247,22 +300,19 @@ pub async fn toggle_project_spec_checklist(
     Path((project_id, spec_id)): Path<(String, String)>,
     Json(request): Json<ChecklistToggleRequest>,
 ) -> ApiResult<Json<ChecklistToggleResponse>> {
-    let (loader, _project) = get_spec_loader(&state, &project_id).await?;
-    let spec = loader.load(&spec_id).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
+    let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
+    require_markdown_adapter(adapter.as_ref())?;
 
-    let spec = spec.ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ApiError::spec_not_found(&spec_id)),
-        )
-    })?;
+    adapter.get(&spec_id).map_err(adapter_error)?;
 
-    // Determine file path: main spec or sub-spec
+    let spec_readme =
+        resolve_markdown_spec_path(&project.specs_dir, &spec_id).ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ApiError::spec_not_found(&spec_id)),
+            )
+        })?;
+
     let file_path = if let Some(ref subspec_file) = request.subspec {
         if subspec_file.contains('/') || subspec_file.contains('\\') {
             return Err((
@@ -270,7 +320,7 @@ pub async fn toggle_project_spec_checklist(
                 Json(ApiError::invalid_request("Invalid sub-spec file")),
             ));
         }
-        let parent_dir = spec.file_path.parent().ok_or_else(|| {
+        let parent_dir = spec_readme.parent().ok_or_else(|| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ApiError::internal_error("Missing spec directory")),
@@ -285,7 +335,7 @@ pub async fn toggle_project_spec_checklist(
         }
         sub_path
     } else {
-        spec.file_path.clone()
+        spec_readme
     };
 
     let content = fs::read_to_string(&file_path).map_err(|e| {
@@ -296,7 +346,6 @@ pub async fn toggle_project_spec_checklist(
     })?;
     let current_hash = hash_raw_content(&content);
 
-    // Verify content hash if provided
     if let Some(expected) = &request.expected_content_hash {
         if expected != &current_hash {
             return Err((
@@ -306,10 +355,8 @@ pub async fn toggle_project_spec_checklist(
         }
     }
 
-    // Split frontmatter from body for main spec files
     let (frontmatter, body) = split_frontmatter(&content);
 
-    // Convert request toggles to core ChecklistToggle
     let toggles: Vec<ChecklistToggle> = request
         .toggles
         .iter()
@@ -319,20 +366,19 @@ pub async fn toggle_project_spec_checklist(
         })
         .collect();
 
-    // Apply checklist toggles to the body
     let (updated_body, results) = apply_checklist_toggles(&body, &toggles)
         .map_err(|e| (StatusCode::BAD_REQUEST, Json(ApiError::invalid_request(&e))))?;
 
-    // Rebuild the full content
     let updated_content = rebuild_content(frontmatter, &updated_body);
 
-    // Write updated content back to the file
     fs::write(&file_path, &updated_content).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiError::internal_error(&e.to_string())),
         )
     })?;
+
+    invalidate_markdown_cache(&project.specs_dir, &file_path);
 
     let new_hash = hash_raw_content(&updated_content);
 
@@ -363,22 +409,19 @@ pub async fn update_project_subspec_raw(
         ));
     }
 
-    let (loader, _project) = get_spec_loader(&state, &project_id).await?;
-    let spec = loader.load(&spec_id).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
+    let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
+    require_markdown_adapter(adapter.as_ref())?;
 
-    let spec = spec.ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ApiError::spec_not_found(&spec_id)),
-        )
-    })?;
+    adapter.get(&spec_id).map_err(adapter_error)?;
 
-    let parent_dir = spec.file_path.parent().ok_or_else(|| {
+    let spec_readme =
+        resolve_markdown_spec_path(&project.specs_dir, &spec_id).ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ApiError::spec_not_found(&spec_id)),
+            )
+        })?;
+    let parent_dir = spec_readme.parent().ok_or_else(|| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiError::internal_error("Missing spec directory")),
@@ -417,6 +460,8 @@ pub async fn update_project_subspec_raw(
         )
     })?;
 
+    invalidate_markdown_cache(&project.specs_dir, &file_path);
+
     let new_hash = hash_raw_content(&request.content);
     Ok(Json(SpecRawResponse {
         content: request.content,
@@ -430,26 +475,19 @@ pub async fn update_project_metadata(
     State(state): State<AppState>,
     Path((project_id, spec_id)): Path<(String, String)>,
     Json(updates): Json<MetadataUpdate>,
-) -> ApiResult<Json<crate::types::UpdateMetadataResponse>> {
-    let (loader, project) = get_spec_loader(&state, &project_id).await?;
+) -> ApiResult<Json<UpdateMetadataResponse>> {
+    let (adapter, _project) = get_adapter_and_project(&state, &project_id).await?;
+    let schema = adapter.schema();
 
-    // Verify spec exists
-    let spec = loader.load(&spec_id).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
-
-    if spec.is_none() {
-        return Err((
-            StatusCode::NOT_FOUND,
-            Json(ApiError::spec_not_found(&spec_id)),
-        ));
-    }
+    let current_doc = adapter.get(&spec_id).map_err(adapter_error)?;
 
     if let Some(expected_hash) = &updates.expected_content_hash {
-        let current_hash = hash_content(&spec.as_ref().unwrap().content);
+        let content = current_doc
+            .fields
+            .get("content")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let current_hash = hash_content(content);
         if expected_hash != &current_hash {
             return Err((
                 StatusCode::CONFLICT,
@@ -458,178 +496,164 @@ pub async fn update_project_metadata(
         }
     }
 
-    // Check if status is being updated to "archived"
-    let is_archiving = updates
-        .status
-        .as_ref()
-        .map(|s| s == "archived")
-        .unwrap_or(false);
-
-    // If archiving, use the archiver to set status (no file move)
-    if is_archiving {
-        let archiver = SpecArchiver::new(&project.specs_dir);
-        archiver.archive(&spec_id).map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ApiError::internal_error(&e.to_string())),
-            )
-        })?;
-
-        // Reload the spec from the same location (status-only archiving)
-        let updated_spec = loader.load(&spec_id).map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ApiError::internal_error(&e.to_string())),
-            )
-        })?;
-
-        let frontmatter = updated_spec
-            .ok_or_else(|| {
-                (
-                    StatusCode::NOT_FOUND,
-                    Json(ApiError::spec_not_found(&spec_id)),
-                )
-            })?
-            .frontmatter;
-
-        return Ok(Json(crate::types::UpdateMetadataResponse {
-            success: true,
-            spec_id: spec_id.clone(),
-            frontmatter: crate::types::FrontmatterResponse::from(&frontmatter),
-        }));
-    }
-
-    // Convert HTTP metadata update to core metadata update
-    let mut core_updates = CoreMetadataUpdate::new();
-    let spec_info = spec.as_ref().unwrap();
-    let mut depends_on = spec_info.frontmatter.depends_on.clone();
-
-    if let Some(additions) = &updates.add_depends_on {
-        for dep in additions {
-            if dep == &spec_id {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    Json(ApiError::invalid_request("Spec cannot depend on itself")),
-                ));
-            }
-            if !depends_on.contains(dep) {
-                depends_on.push(dep.clone());
-            }
-        }
-    }
-
-    if let Some(removals) = &updates.remove_depends_on {
-        depends_on.retain(|dep| !removals.contains(dep));
-    }
+    // Build the UpdateRequest from the inbound patch.
+    let mut req_fields: HashMap<String, FieldValue> = HashMap::new();
+    let mut replace_links: Option<Vec<leanspec_core::ItemLink>> = None;
 
     if let Some(status_str) = &updates.status {
-        let status: SpecStatus = status_str.parse().map_err(|_| {
-            (
-                StatusCode::BAD_REQUEST,
-                Json(ApiError::invalid_request(&format!(
-                    "Invalid status: {}",
-                    status_str
-                ))),
-            )
-        })?;
+        if let Some(key) = schema.key_for_semantic(semantic::STATUS) {
+            validate_enum_value(schema, key, status_str)?;
 
-        if spec_info.frontmatter.status == SpecStatus::Draft
-            && matches!(status, SpecStatus::InProgress | SpecStatus::Complete)
-            && !updates.force.unwrap_or(false)
-        {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(ApiError::invalid_request(
-                    "Cannot skip 'planned' stage. Use force to override.",
-                )),
-            ));
-        }
+            // Markdown-specific transition checks for backwards compatibility.
+            if adapter.capabilities().name == "markdown" {
+                let current_status_str =
+                    semantic_value(&current_doc, schema, semantic::STATUS).unwrap_or("");
+                if current_status_str == "draft"
+                    && matches!(status_str.as_str(), "in-progress" | "complete")
+                    && !updates.force.unwrap_or(false)
+                {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        Json(ApiError::invalid_request(
+                            "Cannot skip 'planned' stage. Use force to override.",
+                        )),
+                    ));
+                }
 
-        // Check umbrella completion when marking as complete
-        if status == SpecStatus::Complete && !updates.force.unwrap_or(false) {
-            let all_specs = loader.load_all().map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ApiError::internal_error(&e.to_string())),
-                )
-            })?;
-
-            let umbrella_verification =
-                CompletionVerifier::verify_umbrella_completion(&spec_id, &all_specs);
-
-            if !umbrella_verification.is_complete {
-                let incomplete_paths: Vec<_> = umbrella_verification
-                    .incomplete_children
-                    .iter()
-                    .map(|c| format!("{} ({})", c.path, c.status))
-                    .collect();
-
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    Json(ApiError::invalid_request(&format!(
-                        "Cannot mark umbrella spec complete: {} child spec(s) are not complete: {}",
-                        umbrella_verification.incomplete_children.len(),
-                        incomplete_paths.join(", ")
-                    ))),
-                ));
+                if status_str == "complete" && !updates.force.unwrap_or(false) {
+                    // Umbrella completion check still uses markdown's
+                    // SpecInfo-typed verifier. The check loads every spec
+                    // through the adapter and projects them to SpecInfo.
+                    let all_docs = adapter
+                        .list(&ListFilter {
+                            include_archived: true,
+                            ..Default::default()
+                        })
+                        .map_err(adapter_error)?;
+                    let all_specs = docs_to_spec_info(&all_docs, schema);
+                    let umbrella =
+                        CompletionVerifier::verify_umbrella_completion(&spec_id, &all_specs);
+                    if !umbrella.is_complete {
+                        let names: Vec<_> = umbrella
+                            .incomplete_children
+                            .iter()
+                            .map(|c| format!("{} ({})", c.path, c.status))
+                            .collect();
+                        return Err((
+                            StatusCode::BAD_REQUEST,
+                            Json(ApiError::invalid_request(&format!(
+                                "Cannot mark umbrella spec complete: {} child spec(s) are not complete: {}",
+                                umbrella.incomplete_children.len(),
+                                names.join(", ")
+                            ))),
+                        ));
+                    }
+                }
             }
-        }
 
-        core_updates = core_updates.with_status(status);
+            req_fields.insert(key.to_string(), FieldValue::String(status_str.clone()));
+        }
     }
 
     if let Some(priority_str) = &updates.priority {
-        let priority = priority_str.parse().map_err(|_| {
-            (
-                StatusCode::BAD_REQUEST,
-                Json(ApiError::invalid_request(&format!(
-                    "Invalid priority: {}",
-                    priority_str
-                ))),
-            )
-        })?;
-        core_updates = core_updates.with_priority(priority);
+        if let Some(key) = schema.key_for_semantic(semantic::PRIORITY) {
+            validate_enum_value(schema, key, priority_str)?;
+            req_fields.insert(key.to_string(), FieldValue::String(priority_str.clone()));
+        }
     }
 
-    if let Some(tags) = updates.tags {
-        core_updates = core_updates.with_tags(tags);
+    if let Some(tags) = &updates.tags {
+        if let Some(key) = schema.key_for_semantic(semantic::TAGS) {
+            req_fields.insert(key.to_string(), FieldValue::Strings(tags.clone()));
+        }
     }
 
-    if let Some(assignee) = updates.assignee {
-        core_updates = core_updates.with_assignee(assignee);
+    if let Some(assignee) = &updates.assignee {
+        if let Some(key) = schema.key_for_semantic(semantic::ASSIGNEE) {
+            req_fields.insert(key.to_string(), FieldValue::String(assignee.clone()));
+        }
     }
 
+    // Depends-on adjustments preserve existing entries and apply add/remove
+    // deltas on top.
     if updates.add_depends_on.is_some() || updates.remove_depends_on.is_some() {
-        core_updates = core_updates.with_depends_on(depends_on);
+        let mut depends: Vec<String> = current_doc
+            .links
+            .iter()
+            .filter(|l| l.link_type == "depends_on")
+            .map(|l| l.target_id.clone())
+            .collect();
+
+        if let Some(additions) = &updates.add_depends_on {
+            for dep in additions {
+                if dep == &spec_id {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        Json(ApiError::invalid_request("Spec cannot depend on itself")),
+                    ));
+                }
+                if !depends.contains(dep) {
+                    depends.push(dep.clone());
+                }
+            }
+        }
+        if let Some(removals) = &updates.remove_depends_on {
+            depends.retain(|d| !removals.contains(d));
+        }
+
+        let mut new_links: Vec<leanspec_core::ItemLink> = current_doc
+            .links
+            .iter()
+            .filter(|l| l.link_type != "depends_on")
+            .cloned()
+            .collect();
+        for target in depends {
+            new_links.push(leanspec_core::ItemLink {
+                link_type: "depends_on".into(),
+                target_id: target,
+                target_title: None,
+            });
+        }
+        replace_links = Some(new_links);
     }
 
     if let Some(parent) = updates.parent {
-        if let Some(parent_name) = parent.as_deref() {
-            if parent_name == spec_id {
+        // `Some(Some(name))` sets a parent, `Some(None)` clears it.
+        let mut links: Vec<leanspec_core::ItemLink> = replace_links
+            .clone()
+            .unwrap_or_else(|| current_doc.links.clone())
+            .into_iter()
+            .filter(|l| l.link_type != "parent")
+            .collect();
+        if let Some(name) = parent {
+            if name == spec_id {
                 return Err((
                     StatusCode::BAD_REQUEST,
                     Json(ApiError::invalid_request("Spec cannot be its own parent")),
                 ));
             }
+            links.push(leanspec_core::ItemLink {
+                link_type: "parent".into(),
+                target_id: name,
+                target_title: None,
+            });
         }
-        core_updates = core_updates.with_parent(parent);
+        replace_links = Some(links);
     }
 
-    // Update metadata using spec writer
-    let writer = SpecWriter::new(&project.specs_dir);
-    let frontmatter = writer
-        .update_metadata(&spec_id, core_updates)
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ApiError::internal_error(&e.to_string())),
-            )
-        })?;
+    let update = UpdateRequest {
+        title: None,
+        fields: req_fields,
+        clear: Vec::new(),
+        replace_links,
+    };
 
-    Ok(Json(crate::types::UpdateMetadataResponse {
+    let updated = adapter.update(&spec_id, &update).map_err(adapter_error)?;
+
+    Ok(Json(UpdateMetadataResponse {
         success: true,
         spec_id: spec_id.clone(),
-        frontmatter: crate::types::FrontmatterResponse::from(&frontmatter),
+        frontmatter: FrontmatterResponse::from_doc(&updated, schema),
     }))
 }
 
@@ -639,17 +663,15 @@ pub async fn batch_spec_metadata(
     Path(project_id): Path<String>,
     Json(request): Json<BatchMetadataRequest>,
 ) -> ApiResult<Json<BatchMetadataResponse>> {
-    let (loader, _project) = get_spec_loader(&state, &project_id).await?;
+    let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
 
-    let all_specs = loader.load_all().map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
-
-    // Build a map of spec_name -> SpecInfo for quick lookup
-    let spec_map: HashMap<String, _> = all_specs.iter().map(|s| (s.path.clone(), s)).collect();
+    let docs = adapter
+        .list(&ListFilter {
+            include_archived: true,
+            ..Default::default()
+        })
+        .map_err(adapter_error)?;
+    let doc_map: HashMap<String, &SpecDoc> = docs.iter().map(|d| (d.id.clone(), d)).collect();
 
     let counter = global_token_counter();
     let fm_validator = global_frontmatter_validator();
@@ -659,59 +681,164 @@ pub async fn batch_spec_metadata(
     let mut result: HashMap<String, SpecMetadata> = HashMap::new();
 
     for spec_name in &request.spec_names {
-        if let Some(spec) = spec_map.get(spec_name) {
-            let content_hash = hash_content(&spec.content);
-            let cache_key = format!("{}::{}", project_id, spec_name);
+        let Some(doc) = doc_map.get(spec_name) else {
+            continue;
+        };
+        let content = doc
+            .fields
+            .get("content")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let content_hash = hash_content(content);
+        let cache_key = format!("{}::{}", project_id, spec_name);
 
-            if let Ok(cache) = BATCH_METADATA_CACHE.read() {
-                if let Some((cached_hash, cached_metadata)) = cache.get(&cache_key) {
-                    if cached_hash == &content_hash {
-                        result.insert(spec_name.clone(), cached_metadata.clone());
-                        continue;
-                    }
+        if let Ok(cache) = BATCH_METADATA_CACHE.read() {
+            if let Some((cached_hash, cached_metadata)) = cache.get(&cache_key) {
+                if cached_hash == &content_hash {
+                    result.insert(spec_name.clone(), cached_metadata.clone());
+                    continue;
                 }
             }
+        }
 
-            // Compute token count (simple version - no detailed breakdown)
-            let (total, status) = counter.count_spec_simple(&spec.content);
-            let token_status_str = match status {
-                TokenStatus::Optimal => "optimal",
-                TokenStatus::Good => "good",
-                TokenStatus::Warning => "warning",
-                TokenStatus::Excessive => "critical",
-            };
+        let (total, status) = counter.count_spec_simple(content);
+        let token_status_str = match status {
+            TokenStatus::Optimal => "optimal",
+            TokenStatus::Good => "good",
+            TokenStatus::Warning => "warning",
+            TokenStatus::Excessive => "critical",
+        };
 
-            // Compute validation status
-            let mut validation_result = ValidationResult::new(&spec.path);
-            validation_result.merge(fm_validator.validate(spec));
-            validation_result.merge(struct_validator.validate(spec));
-            validation_result.merge(token_validator.validate(spec));
+        let validation_status_str = if adapter.capabilities().name == "markdown" {
+            // Reconstruct SpecInfo from the on-disk file for the markdown
+            // validators. Non-markdown adapters get "pass" by default until
+            // schema-driven validation lands in spec #262.
+            match resolve_markdown_spec_path(&project.specs_dir, spec_name) {
+                Some(file_path) => match build_spec_info(doc, file_path) {
+                    Some(info) => {
+                        let mut validation_result = ValidationResult::new(&info.path);
+                        validation_result.merge(fm_validator.validate(&info));
+                        validation_result.merge(struct_validator.validate(&info));
+                        validation_result.merge(token_validator.validate(&info));
 
-            let validation_status_str = if validation_result.errors.is_empty() {
-                "pass"
-            } else if validation_result
-                .errors
-                .iter()
-                .any(|e| e.severity == leanspec_core::ErrorSeverity::Error)
-            {
-                "fail"
-            } else {
-                "warn"
-            };
-
-            let metadata = SpecMetadata {
-                token_count: total,
-                token_status: token_status_str.to_string(),
-                validation_status: validation_status_str.to_string(),
-            };
-
-            result.insert(spec_name.clone(), metadata.clone());
-
-            if let Ok(mut cache) = BATCH_METADATA_CACHE.write() {
-                cache.insert(cache_key, (content_hash, metadata));
+                        if validation_result.errors.is_empty() {
+                            "pass"
+                        } else if validation_result
+                            .errors
+                            .iter()
+                            .any(|e| e.severity == leanspec_core::ErrorSeverity::Error)
+                        {
+                            "fail"
+                        } else {
+                            "warn"
+                        }
+                    }
+                    None => "pass",
+                },
+                None => "pass",
             }
+        } else {
+            "pass"
+        };
+
+        let metadata = SpecMetadata {
+            token_count: total,
+            token_status: token_status_str.to_string(),
+            validation_status: validation_status_str.to_string(),
+        };
+
+        result.insert(spec_name.clone(), metadata.clone());
+
+        if let Ok(mut cache) = BATCH_METADATA_CACHE.write() {
+            cache.insert(cache_key, (content_hash, metadata));
         }
     }
 
     Ok(Json(BatchMetadataResponse { specs: result }))
+}
+
+/// Invalidate the markdown adapter's static spec cache for a path. Safe to
+/// call from non-markdown contexts (a no-op when the path is unknown).
+fn invalidate_markdown_cache(specs_dir: &FsPath, path: &FsPath) {
+    leanspec_core::adapters::markdown::MarkdownAdapter::new(specs_dir).invalidate_path(path);
+}
+
+fn build_spec_info(doc: &SpecDoc, file_path: std::path::PathBuf) -> Option<SpecInfo> {
+    let content = fs::read_to_string(&file_path).ok()?;
+    let parser = FrontmatterParser::new();
+    let (frontmatter, body) = parser.parse(&content).ok()?;
+    let title = body
+        .lines()
+        .find(|l| l.starts_with("# "))
+        .map(|l| l.trim_start_matches("# ").to_string())
+        .unwrap_or_else(|| doc.title.clone());
+    Some(SpecInfo {
+        path: doc.id.clone(),
+        title,
+        frontmatter,
+        content: body,
+        file_path,
+        is_sub_spec: false,
+        parent_spec: None,
+    })
+}
+
+/// Project the adapter's documents to markdown `SpecInfo` for the umbrella
+/// verifier. Only meaningful for markdown projects.
+fn docs_to_spec_info(docs: &[SpecDoc], schema: &SpecSchema) -> Vec<SpecInfo> {
+    use leanspec_core::adapters::markdown::SpecFrontmatter;
+    docs.iter()
+        .map(|doc| {
+            let status_str = doc
+                .fields
+                .get(
+                    schema
+                        .key_for_semantic(semantic::STATUS)
+                        .unwrap_or("status"),
+                )
+                .and_then(|v| v.as_str())
+                .unwrap_or("draft");
+            let status = status_str
+                .parse::<SpecStatus>()
+                .unwrap_or(SpecStatus::Draft);
+            let parent = doc
+                .links
+                .iter()
+                .find(|l| l.link_type == "parent")
+                .map(|l| l.target_id.clone());
+
+            let frontmatter = SpecFrontmatter {
+                status,
+                created: String::new(),
+                priority: None,
+                tags: Vec::new(),
+                depends_on: Vec::new(),
+                parent,
+                assignee: None,
+                reviewer: None,
+                issue: None,
+                pr: None,
+                epic: None,
+                breaking: None,
+                due: None,
+                updated: None,
+                completed: None,
+                created_at: None,
+                updated_at: None,
+                completed_at: None,
+                transitions: Vec::new(),
+                custom: std::collections::HashMap::new(),
+            };
+
+            SpecInfo {
+                path: doc.id.clone(),
+                title: doc.title.clone(),
+                frontmatter,
+                content: String::new(),
+                file_path: std::path::PathBuf::new(),
+                is_sub_spec: false,
+                parent_spec: None,
+            }
+        })
+        .collect()
 }

--- a/rust/leanspec-http/src/lib.rs
+++ b/rust/leanspec-http/src/lib.rs
@@ -22,6 +22,7 @@
 //! }
 //! ```
 
+pub mod adapter_resolution;
 pub mod config;
 pub mod error;
 pub mod handlers;

--- a/rust/leanspec-http/src/routes.rs
+++ b/rust/leanspec-http/src/routes.rs
@@ -65,6 +65,11 @@ pub fn create_router(state: AppState) -> Router {
             "/api/projects/{id}/adapter",
             get(handlers::get_project_adapter_capabilities),
         )
+        // Active adapter schema (per-project)
+        .route(
+            "/api/projects/{id}/schema",
+            get(handlers::get_project_schema),
+        )
         // Project routes
         .route("/api/projects", get(handlers::list_projects))
         .route("/api/projects", post(handlers::add_project))

--- a/rust/leanspec-http/src/state.rs
+++ b/rust/leanspec-http/src/state.rs
@@ -5,8 +5,11 @@
 use crate::config::ServerConfig;
 use crate::error::ServerError;
 use crate::project_registry::{Project, ProjectRegistry};
-use crate::watcher::{sse_connection_limit, watch_debounce, watch_enabled, FileWatcher};
-use std::path::PathBuf;
+use crate::watcher::{
+    sse_connection_limit, watch_debounce, watch_enabled, FileWatcher, MarkdownWatchTarget,
+};
+use leanspec_core::adapters::AdapterRegistry;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::{RwLock, Semaphore};
 
@@ -42,22 +45,7 @@ impl AppState {
             }
         }
 
-        let file_watcher = if watch_enabled() {
-            let roots: Vec<_> = registry.all().iter().map(|p| p.specs_dir.clone()).collect();
-            if roots.is_empty() {
-                None
-            } else {
-                match FileWatcher::new(roots, watch_debounce()) {
-                    Ok(watcher) => Some(Arc::new(watcher)),
-                    Err(err) => {
-                        tracing::warn!("Failed to initialize spec watcher: {}", err);
-                        None
-                    }
-                }
-            }
-        } else {
-            None
-        };
+        let file_watcher = build_file_watcher(&registry);
 
         let sse_connections = Arc::new(Semaphore::new(sse_connection_limit()));
 
@@ -71,12 +59,7 @@ impl AppState {
 
     /// Create state with an existing registry (for testing)
     pub async fn with_registry(config: ServerConfig, registry: ProjectRegistry) -> Self {
-        let file_watcher = if watch_enabled() {
-            let roots: Vec<_> = registry.all().iter().map(|p| p.specs_dir.clone()).collect();
-            FileWatcher::new(roots, watch_debounce()).ok().map(Arc::new)
-        } else {
-            None
-        };
+        let file_watcher = build_file_watcher(&registry);
         let sse_connections = Arc::new(Semaphore::new(sse_connection_limit()));
         Self {
             config: Arc::new(config),
@@ -85,6 +68,55 @@ impl AppState {
             sse_connections,
         }
     }
+}
+
+/// Build a file watcher restricted to projects whose adapter is markdown.
+fn build_file_watcher(registry: &ProjectRegistry) -> Option<Arc<FileWatcher>> {
+    if !watch_enabled() {
+        return None;
+    }
+
+    let targets: Vec<MarkdownWatchTarget> = registry
+        .all()
+        .into_iter()
+        .filter(|project| project_uses_markdown_adapter(&project.path))
+        .map(|project| MarkdownWatchTarget::new(project.specs_dir.clone()))
+        .collect();
+
+    if targets.is_empty() {
+        return None;
+    }
+
+    match FileWatcher::new(targets, watch_debounce()) {
+        Ok(watcher) => Some(Arc::new(watcher)),
+        Err(err) => {
+            tracing::warn!("Failed to initialize spec watcher: {}", err);
+            None
+        }
+    }
+}
+
+/// Inspect a project's adapter config and return true when it resolves to a
+/// markdown adapter (or when no adapter config exists, since markdown is the
+/// default).
+fn project_uses_markdown_adapter(project_path: &Path) -> bool {
+    const CANDIDATES: &[&str] = &[
+        "leanspec.adapter.yaml",
+        ".lean-spec/adapter.yaml",
+        "leanspec.provider.yaml",
+        ".lean-spec/provider.yaml",
+    ];
+
+    for candidate in CANDIDATES {
+        let path = project_path.join(candidate);
+        if path.exists() {
+            match AdapterRegistry::load_config(&path) {
+                Ok(cfg) => return cfg.adapter == "markdown",
+                Err(_) => return false,
+            }
+        }
+    }
+    true
 }
 
 /// Resolve a default project path by walking up to find a `specs` directory.

--- a/rust/leanspec-http/src/state.rs
+++ b/rust/leanspec-http/src/state.rs
@@ -2,6 +2,7 @@
 //!
 //! Shared state for the HTTP server using Arc for thread-safety.
 
+use crate::adapter_resolution::find_adapter_config;
 use crate::config::ServerConfig;
 use crate::error::ServerError;
 use crate::project_registry::{Project, ProjectRegistry};
@@ -98,25 +99,17 @@ fn build_file_watcher(registry: &ProjectRegistry) -> Option<Arc<FileWatcher>> {
 
 /// Inspect a project's adapter config and return true when it resolves to a
 /// markdown adapter (or when no adapter config exists, since markdown is the
-/// default).
+/// default). Uses the same lookup order as request-time adapter resolution so
+/// the watcher never disagrees with the handlers about which projects need
+/// file events.
 fn project_uses_markdown_adapter(project_path: &Path) -> bool {
-    const CANDIDATES: &[&str] = &[
-        "leanspec.adapter.yaml",
-        ".lean-spec/adapter.yaml",
-        "leanspec.provider.yaml",
-        ".lean-spec/provider.yaml",
-    ];
-
-    for candidate in CANDIDATES {
-        let path = project_path.join(candidate);
-        if path.exists() {
-            match AdapterRegistry::load_config(&path) {
-                Ok(cfg) => return cfg.adapter == "markdown",
-                Err(_) => return false,
-            }
-        }
+    match find_adapter_config(project_path) {
+        Some(path) => match AdapterRegistry::load_config(&path) {
+            Ok(cfg) => cfg.adapter == "markdown",
+            Err(_) => false,
+        },
+        None => true,
     }
-    true
 }
 
 /// Resolve a default project path by walking up to find a `specs` directory.

--- a/rust/leanspec-http/src/types/specs.rs
+++ b/rust/leanspec-http/src/types/specs.rs
@@ -2,14 +2,59 @@
 
 use chrono::{DateTime, Utc};
 use leanspec_core::io::hash_content;
-use leanspec_core::{
-    global_frontmatter_validator, global_structure_validator, global_token_count_validator,
-    global_token_counter, SpecInfo, SpecPriority, SpecStats, SpecStatus, TokenStatus,
-    ValidationResult,
-};
+use leanspec_core::{global_token_counter, semantic, FieldValue, SpecDoc, SpecSchema, TokenStatus};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use ts_rs::TS;
+
+/// Markdown adapter field key for the body content.
+const FIELD_CONTENT: &str = "content";
+/// Markdown adapter link type for parent relationships.
+const LINK_PARENT: &str = "parent";
+/// Markdown adapter link type for dependency relationships.
+const LINK_DEPENDS_ON: &str = "depends_on";
+
+fn doc_field_str<'a>(doc: &'a SpecDoc, key: &str) -> Option<&'a str> {
+    doc.fields.get(key)?.as_str()
+}
+
+fn doc_field_strings(doc: &SpecDoc, key: &str) -> Vec<String> {
+    match doc.fields.get(key) {
+        Some(FieldValue::Strings(v)) => v.clone(),
+        _ => Vec::new(),
+    }
+}
+
+fn semantic_str<'a>(doc: &'a SpecDoc, schema: &SpecSchema, semantic: &str) -> Option<&'a str> {
+    let key = schema.key_for_semantic(semantic)?;
+    doc_field_str(doc, key)
+}
+
+fn semantic_strings(doc: &SpecDoc, schema: &SpecSchema, semantic: &str) -> Vec<String> {
+    schema
+        .key_for_semantic(semantic)
+        .map(|key| doc_field_strings(doc, key))
+        .unwrap_or_default()
+}
+
+fn spec_number_from_id(id: &str) -> Option<u32> {
+    id.split('-').next().and_then(|s| s.parse().ok())
+}
+
+fn link_targets(doc: &SpecDoc, link_type: &str) -> Vec<String> {
+    doc.links
+        .iter()
+        .filter(|l| l.link_type == link_type)
+        .map(|l| l.target_id.clone())
+        .collect()
+}
+
+fn parent_link(doc: &SpecDoc) -> Option<String> {
+    doc.links
+        .iter()
+        .find(|l| l.link_type == LINK_PARENT)
+        .map(|l| l.target_id.clone())
+}
 
 /// Lightweight spec for list views
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
@@ -49,93 +94,49 @@ pub struct SpecSummary {
     pub relationships: Option<SpecRelationships>,
 }
 
-impl From<&SpecInfo> for SpecSummary {
-    fn from(spec: &SpecInfo) -> Self {
-        // Compute token count from spec content
-        let counter = global_token_counter();
-        let token_result = counter.count_spec(&spec.content);
-        let token_status_str = match token_result.status {
-            TokenStatus::Optimal => "optimal",
-            TokenStatus::Good => "good",
-            TokenStatus::Warning => "warning",
-            TokenStatus::Excessive => "critical",
-        };
-
-        // Compute validation status
-        let fm_validator = global_frontmatter_validator();
-        let struct_validator = global_structure_validator();
-        let token_validator = global_token_count_validator();
-
-        let mut validation_result = ValidationResult::new(&spec.path);
-        validation_result.merge(fm_validator.validate(spec));
-        validation_result.merge(struct_validator.validate(spec));
-        validation_result.merge(token_validator.validate(spec));
-
-        let validation_status_str = if validation_result.errors.is_empty() {
-            "pass"
-        } else if validation_result
-            .errors
-            .iter()
-            .any(|e| e.severity == leanspec_core::ErrorSeverity::Error)
-        {
-            "fail"
-        } else {
-            "warn"
-        };
-
-        Self {
-            project_id: None,
-            id: spec.path.clone(),
-            spec_number: spec.number(),
-            spec_name: spec.path.clone(),
-            title: Some(spec.title.clone()),
-            status: spec.frontmatter.status.to_string(),
-            priority: spec.frontmatter.priority.map(|p| p.to_string()),
-            tags: spec.frontmatter.tags.clone(),
-            assignee: spec.frontmatter.assignee.clone(),
-            created_at: spec.frontmatter.created_at,
-            updated_at: spec.frontmatter.updated_at,
-            completed_at: spec.frontmatter.completed_at,
-            file_path: spec.file_path.to_string_lossy().to_string(),
-            depends_on: spec.frontmatter.depends_on.clone(),
-            parent: spec.frontmatter.parent.clone(),
-            children: Vec::new(),
-            required_by: Vec::new(), // Will be computed when needed
-            content_hash: Some(hash_content(&spec.content)),
-            token_count: Some(token_result.total),
-            token_status: Some(token_status_str.to_string()),
-            validation_status: Some(validation_status_str.to_string()),
-            relationships: None,
-        }
-    }
-}
-
 impl SpecSummary {
-    pub fn from_without_computed(spec: &SpecInfo) -> Self {
+    /// Build a summary from an adapter document without computing tokens or
+    /// validation status — used by list handlers that enrich the result later.
+    pub fn from_doc(doc: &SpecDoc, schema: &SpecSchema) -> Self {
+        let content = doc_field_str(doc, FIELD_CONTENT).unwrap_or("");
         Self {
             project_id: None,
-            id: spec.path.clone(),
-            spec_number: spec.number(),
-            spec_name: spec.path.clone(),
-            title: Some(spec.title.clone()),
-            status: spec.frontmatter.status.to_string(),
-            priority: spec.frontmatter.priority.map(|p| p.to_string()),
-            tags: spec.frontmatter.tags.clone(),
-            assignee: spec.frontmatter.assignee.clone(),
-            created_at: spec.frontmatter.created_at,
-            updated_at: spec.frontmatter.updated_at,
-            completed_at: spec.frontmatter.completed_at,
-            file_path: spec.file_path.to_string_lossy().to_string(),
-            depends_on: spec.frontmatter.depends_on.clone(),
-            parent: spec.frontmatter.parent.clone(),
+            id: doc.id.clone(),
+            spec_number: spec_number_from_id(&doc.id),
+            spec_name: doc.id.clone(),
+            title: Some(doc.title.clone()),
+            status: semantic_str(doc, schema, semantic::STATUS)
+                .unwrap_or("")
+                .to_string(),
+            priority: semantic_str(doc, schema, semantic::PRIORITY).map(String::from),
+            tags: semantic_strings(doc, schema, semantic::TAGS),
+            assignee: semantic_str(doc, schema, semantic::ASSIGNEE).map(String::from),
+            created_at: doc.created_at,
+            updated_at: doc.updated_at,
+            completed_at: None,
+            file_path: doc.url.clone().unwrap_or_default(),
+            depends_on: link_targets(doc, LINK_DEPENDS_ON),
+            parent: parent_link(doc),
             children: Vec::new(),
             required_by: Vec::new(),
-            content_hash: Some(hash_content(&spec.content)),
+            content_hash: Some(hash_content(content)),
             token_count: None,
             token_status: None,
             validation_status: None,
             relationships: None,
         }
+    }
+
+    /// Build a summary from an adapter document with token counts computed
+    /// from `fields["content"]`.
+    pub fn from_doc_with_tokens(doc: &SpecDoc, schema: &SpecSchema) -> Self {
+        let mut summary = Self::from_doc(doc, schema);
+        let content = doc_field_str(doc, FIELD_CONTENT).unwrap_or("");
+        let counter = global_token_counter();
+        let token_result = counter.count_spec(content);
+        summary.token_count = Some(token_result.total);
+        summary.token_status = Some(token_status_str(token_result.status).to_string());
+        summary
     }
 
     pub fn with_project_id(mut self, project_id: &str) -> Self {
@@ -150,6 +151,15 @@ impl SpecSummary {
             required_by: Some(required_by),
         });
         self
+    }
+}
+
+impl From<&SpecDoc> for SpecSummary {
+    fn from(doc: &SpecDoc) -> Self {
+        // Without a schema available, look up well-known field keys directly.
+        // Callers that have the schema should prefer `from_doc_with_tokens`.
+        let placeholder = placeholder_schema();
+        Self::from_doc_with_tokens(doc, &placeholder)
     }
 }
 
@@ -192,6 +202,107 @@ pub struct SpecDetail {
     pub relationships: Option<SpecRelationships>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sub_specs: Option<Vec<SubSpec>>,
+}
+
+impl SpecDetail {
+    pub fn from_doc(doc: &SpecDoc, schema: &SpecSchema) -> Self {
+        let content = doc_field_str(doc, FIELD_CONTENT).unwrap_or("").to_string();
+        let counter = global_token_counter();
+        let token_result = counter.count_spec(&content);
+
+        Self {
+            project_id: None,
+            id: doc.id.clone(),
+            spec_number: spec_number_from_id(&doc.id),
+            spec_name: doc.id.clone(),
+            title: Some(doc.title.clone()),
+            status: semantic_str(doc, schema, semantic::STATUS)
+                .unwrap_or("")
+                .to_string(),
+            priority: semantic_str(doc, schema, semantic::PRIORITY).map(String::from),
+            tags: semantic_strings(doc, schema, semantic::TAGS),
+            assignee: semantic_str(doc, schema, semantic::ASSIGNEE).map(String::from),
+            content_md: content.clone(),
+            created_at: doc.created_at,
+            updated_at: doc.updated_at,
+            completed_at: None,
+            file_path: doc.url.clone().unwrap_or_default(),
+            depends_on: link_targets(doc, LINK_DEPENDS_ON),
+            parent: parent_link(doc),
+            children: Vec::new(),
+            required_by: Vec::new(),
+            content_hash: Some(hash_content(&content)),
+            token_count: Some(token_result.total),
+            token_status: Some(token_status_str(token_result.status).to_string()),
+            validation_status: None,
+            relationships: None,
+            sub_specs: None,
+        }
+    }
+
+    pub fn with_project_id(mut self, project_id: String) -> Self {
+        self.project_id = Some(project_id);
+        self
+    }
+
+    pub fn with_file_path(mut self, file_path: String) -> Self {
+        self.file_path = file_path;
+        self
+    }
+}
+
+impl From<&SpecDoc> for SpecDetail {
+    fn from(doc: &SpecDoc) -> Self {
+        let placeholder = placeholder_schema();
+        Self::from_doc(doc, &placeholder)
+    }
+}
+
+fn token_status_str(status: TokenStatus) -> &'static str {
+    match status {
+        TokenStatus::Optimal => "optimal",
+        TokenStatus::Good => "good",
+        TokenStatus::Warning => "warning",
+        TokenStatus::Excessive => "critical",
+    }
+}
+
+/// Build a minimal schema with well-known semantic keys mapped to their
+/// conventional field keys. Used when callers don't have access to the
+/// adapter's real schema.
+fn placeholder_schema() -> SpecSchema {
+    use leanspec_core::{FieldDef, FieldDisplay, FieldKind};
+
+    fn enum_field(key: &str, label: &str, semantic_key: &str, multi: bool) -> FieldDef {
+        FieldDef {
+            key: key.into(),
+            label: label.into(),
+            kind: FieldKind::Enum {
+                options: vec![],
+                multi,
+                allow_custom: true,
+                dynamic: false,
+            },
+            display: FieldDisplay::Inline,
+            required: false,
+            semantic: Some(semantic_key.to_string()),
+            ai_hint: None,
+            placeholder: None,
+        }
+    }
+
+    SpecSchema {
+        id: "placeholder".into(),
+        name: "Placeholder".into(),
+        extends: None,
+        fields: vec![
+            enum_field("status", "Status", semantic::STATUS, false),
+            enum_field("priority", "Priority", semantic::PRIORITY, false),
+            enum_field("tags", "Tags", semantic::TAGS, true),
+            enum_field("assignee", "Assignee", semantic::ASSIGNEE, false),
+        ],
+        link_types: vec![],
+    }
 }
 
 /// Raw spec content response
@@ -267,76 +378,6 @@ pub struct CreateSpecRequest {
     pub depends_on: Option<Vec<String>>,
     pub template: Option<String>,
     pub content: Option<String>,
-}
-
-impl From<&SpecInfo> for SpecDetail {
-    fn from(spec: &SpecInfo) -> Self {
-        // Compute token count from spec content
-        let counter = global_token_counter();
-        let token_result = counter.count_spec(&spec.content);
-        let token_status_str = match token_result.status {
-            TokenStatus::Optimal => "optimal",
-            TokenStatus::Good => "good",
-            TokenStatus::Warning => "warning",
-            TokenStatus::Excessive => "critical",
-        };
-
-        // Compute validation status
-        let fm_validator = global_frontmatter_validator();
-        let struct_validator = global_structure_validator();
-        let token_validator = global_token_count_validator();
-
-        let mut validation_result = ValidationResult::new(&spec.path);
-        validation_result.merge(fm_validator.validate(spec));
-        validation_result.merge(struct_validator.validate(spec));
-        validation_result.merge(token_validator.validate(spec));
-
-        let validation_status_str = if validation_result.errors.is_empty() {
-            "pass"
-        } else if validation_result
-            .errors
-            .iter()
-            .any(|e| e.severity == leanspec_core::ErrorSeverity::Error)
-        {
-            "fail"
-        } else {
-            "warn"
-        };
-
-        Self {
-            project_id: None,
-            id: spec.path.clone(),
-            spec_number: spec.number(),
-            spec_name: spec.path.clone(),
-            title: Some(spec.title.clone()),
-            status: spec.frontmatter.status.to_string(),
-            priority: spec.frontmatter.priority.map(|p| p.to_string()),
-            tags: spec.frontmatter.tags.clone(),
-            assignee: spec.frontmatter.assignee.clone(),
-            content_md: spec.content.clone(),
-            created_at: spec.frontmatter.created_at,
-            updated_at: spec.frontmatter.updated_at,
-            completed_at: spec.frontmatter.completed_at,
-            file_path: spec.file_path.to_string_lossy().to_string(),
-            depends_on: spec.frontmatter.depends_on.clone(),
-            parent: spec.frontmatter.parent.clone(),
-            children: Vec::new(),
-            required_by: Vec::new(), // Will be computed when needed
-            content_hash: Some(hash_content(&spec.content)),
-            token_count: Some(token_result.total),
-            token_status: Some(token_status_str.to_string()),
-            validation_status: Some(validation_status_str.to_string()),
-            relationships: None,
-            sub_specs: None,
-        }
-    }
-}
-
-impl SpecDetail {
-    pub fn with_project_id(mut self, project_id: String) -> Self {
-        self.project_id = Some(project_id);
-        self
-    }
 }
 
 /// Spec relationships container
@@ -465,61 +506,6 @@ pub struct StatusCountItem {
 pub struct PriorityCountItem {
     pub priority: String,
     pub count: usize,
-}
-
-impl StatsResponse {
-    pub fn from_project_stats(stats: SpecStats, project_id: &str) -> Self {
-        let specs_by_status = vec![
-            StatusCountItem {
-                status: "draft".to_string(),
-                count: *stats.by_status.get(&SpecStatus::Draft).unwrap_or(&0),
-            },
-            StatusCountItem {
-                status: "planned".to_string(),
-                count: *stats.by_status.get(&SpecStatus::Planned).unwrap_or(&0),
-            },
-            StatusCountItem {
-                status: "in-progress".to_string(),
-                count: *stats.by_status.get(&SpecStatus::InProgress).unwrap_or(&0),
-            },
-            StatusCountItem {
-                status: "complete".to_string(),
-                count: *stats.by_status.get(&SpecStatus::Complete).unwrap_or(&0),
-            },
-            StatusCountItem {
-                status: "archived".to_string(),
-                count: *stats.by_status.get(&SpecStatus::Archived).unwrap_or(&0),
-            },
-        ];
-
-        let specs_by_priority = vec![
-            PriorityCountItem {
-                priority: "low".to_string(),
-                count: *stats.by_priority.get(&SpecPriority::Low).unwrap_or(&0),
-            },
-            PriorityCountItem {
-                priority: "medium".to_string(),
-                count: *stats.by_priority.get(&SpecPriority::Medium).unwrap_or(&0),
-            },
-            PriorityCountItem {
-                priority: "high".to_string(),
-                count: *stats.by_priority.get(&SpecPriority::High).unwrap_or(&0),
-            },
-            PriorityCountItem {
-                priority: "critical".to_string(),
-                count: *stats.by_priority.get(&SpecPriority::Critical).unwrap_or(&0),
-            },
-        ];
-
-        Self {
-            total_projects: 1,
-            total_specs: stats.total,
-            specs_by_status,
-            specs_by_priority,
-            completion_rate: stats.completion_percentage(),
-            project_id: Some(project_id.to_string()),
-        }
-    }
 }
 
 /// Dependency graph response
@@ -766,19 +752,27 @@ pub struct FrontmatterResponse {
     pub completed_at: Option<DateTime<Utc>>,
 }
 
-impl From<&leanspec_core::SpecFrontmatter> for FrontmatterResponse {
-    fn from(fm: &leanspec_core::SpecFrontmatter) -> Self {
+impl FrontmatterResponse {
+    /// Build a frontmatter response from an adapter document, using the
+    /// adapter's schema to find semantic field keys.
+    pub fn from_doc(doc: &SpecDoc, schema: &SpecSchema) -> Self {
         Self {
-            status: fm.status.to_string(),
-            created: fm.created.clone(),
-            priority: fm.priority.map(|p| p.to_string()),
-            tags: fm.tags.clone(),
-            depends_on: fm.depends_on.clone(),
-            parent: fm.parent.clone(),
-            assignee: fm.assignee.clone(),
-            created_at: fm.created_at,
-            updated_at: fm.updated_at,
-            completed_at: fm.completed_at,
+            status: semantic_str(doc, schema, semantic::STATUS)
+                .unwrap_or("")
+                .to_string(),
+            created: doc
+                .created_at
+                .map(|t| t.format("%Y-%m-%d").to_string())
+                .or_else(|| doc_field_str(doc, "created").map(String::from))
+                .unwrap_or_default(),
+            priority: semantic_str(doc, schema, semantic::PRIORITY).map(String::from),
+            tags: semantic_strings(doc, schema, semantic::TAGS),
+            depends_on: link_targets(doc, LINK_DEPENDS_ON),
+            parent: parent_link(doc),
+            assignee: semantic_str(doc, schema, semantic::ASSIGNEE).map(String::from),
+            created_at: doc.created_at,
+            updated_at: doc.updated_at,
+            completed_at: None,
         }
     }
 }

--- a/rust/leanspec-http/src/watcher.rs
+++ b/rust/leanspec-http/src/watcher.rs
@@ -1,11 +1,17 @@
 //! File watcher for spec changes
+//!
+//! File watching is markdown-specific — the watcher tracks on-disk markdown
+//! roots and invalidates the markdown adapter's cache when files change.
+//! For non-markdown adapters file watching is a no-op (the project root is
+//! simply not registered with the watcher).
 
 use crate::error::ServerError;
-use leanspec_core::SpecLoader;
+use leanspec_core::adapters::markdown::MarkdownAdapter;
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::runtime::Handle;
 use tokio::sync::{broadcast, mpsc};
@@ -25,6 +31,20 @@ pub struct SpecChangeEvent {
     pub path: String,
 }
 
+/// One watched markdown root with the typed adapter handle for cache
+/// invalidation.
+pub struct MarkdownWatchTarget {
+    pub specs_dir: PathBuf,
+    pub adapter: Arc<MarkdownAdapter>,
+}
+
+impl MarkdownWatchTarget {
+    pub fn new(specs_dir: PathBuf) -> Self {
+        let adapter = Arc::new(MarkdownAdapter::new(&specs_dir));
+        Self { specs_dir, adapter }
+    }
+}
+
 pub struct FileWatcher {
     _watcher: RecommendedWatcher,
     tx: broadcast::Sender<SpecChangeEvent>,
@@ -32,7 +52,7 @@ pub struct FileWatcher {
 }
 
 impl FileWatcher {
-    pub fn new(roots: Vec<PathBuf>, debounce: Duration) -> Result<Self, ServerError> {
+    pub fn new(targets: Vec<MarkdownWatchTarget>, debounce: Duration) -> Result<Self, ServerError> {
         let (tx, _) = broadcast::channel(200);
         let (raw_tx, mut raw_rx) = mpsc::unbounded_channel::<Event>();
 
@@ -43,13 +63,21 @@ impl FileWatcher {
         })
         .map_err(|e| ServerError::ServerError(format!("Failed to start watcher: {e}")))?;
 
-        for root in &roots {
-            watcher.watch(root, RecursiveMode::Recursive).map_err(|e| {
-                ServerError::ServerError(format!("Failed to watch {}: {e}", root.display()))
-            })?;
+        for target in &targets {
+            watcher
+                .watch(&target.specs_dir, RecursiveMode::Recursive)
+                .map_err(|e| {
+                    ServerError::ServerError(format!(
+                        "Failed to watch {}: {e}",
+                        target.specs_dir.display()
+                    ))
+                })?;
         }
 
-        let roots_clone = roots.clone();
+        let targets = Arc::new(targets);
+        let roots: Vec<PathBuf> = targets.iter().map(|t| t.specs_dir.clone()).collect();
+        let targets_for_loop = targets.clone();
+        let roots_for_loop = roots.clone();
         let tx_clone = tx.clone();
         let debounce_interval = if debounce.is_zero() {
             Duration::from_millis(300)
@@ -75,8 +103,13 @@ impl FileWatcher {
                                     continue;
                                 }
 
-                                // Keep core spec cache coherent with on-disk changes.
-                                SpecLoader::invalidate_cached_path(&path);
+                                // Keep the markdown adapter's spec cache
+                                // coherent with on-disk changes.
+                                for target in targets_for_loop.iter() {
+                                    if path.starts_with(&target.specs_dir) {
+                                        target.adapter.invalidate_path(&path);
+                                    }
+                                }
 
                                 pending.insert(path, (kind, Instant::now()));
                             }
@@ -91,7 +124,7 @@ impl FileWatcher {
                         std::mem::swap(&mut drained, &mut pending);
 
                         for (path, (kind, _)) in drained {
-                            if let Some(event) = to_spec_event(&roots_clone, path, kind) {
+                            if let Some(event) = to_spec_event(&roots_for_loop, path, kind) {
                                 let _ = tx_clone.send(event);
                             }
                         }

--- a/rust/leanspec-http/tests/export_bindings.rs
+++ b/rust/leanspec-http/tests/export_bindings.rs
@@ -1,4 +1,4 @@
-use leanspec_core::{SpecPriority, SpecStatus, StatusTransition};
+use leanspec_core::adapters::markdown::{SpecPriority, SpecStatus, StatusTransition};
 use leanspec_http::types::{
     BatchMetadataRequest, BatchMetadataResponse, ChecklistToggleItem, ChecklistToggleRequest,
     ChecklistToggleResponse, ChecklistToggledResult, ConfigFeatures, ConfigStructure, ContextFile,

--- a/rust/leanspec-http/tests/schema_test.rs
+++ b/rust/leanspec-http/tests/schema_test.rs
@@ -1,0 +1,51 @@
+//! Integration tests for the per-project schema endpoint and the
+//! markdown-only guards added in spec #261.
+
+mod common;
+
+use axum::http::StatusCode;
+use leanspec_http::create_router;
+use serde_json::Value;
+use tempfile::TempDir;
+
+use common::*;
+
+#[tokio::test]
+async fn test_get_project_schema_returns_markdown_schema() {
+    let temp_dir = TempDir::new().unwrap();
+    let state = create_test_state(&temp_dir).await;
+    let app = create_router(state.clone());
+
+    let project_id = {
+        let reg = state.registry.read().await;
+        let projects = reg.all();
+        projects.first().unwrap().id.clone()
+    };
+
+    let (status, body) =
+        make_request(app, "GET", &format!("/api/projects/{}/schema", project_id)).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let schema: Value = serde_json::from_str(&body).unwrap();
+
+    // The markdown adapter's schema id should round-trip into the response.
+    assert_eq!(schema["id"], "leanspec:markdown");
+    assert_eq!(schema["name"], "Markdown");
+    let fields = schema["fields"].as_array().unwrap();
+
+    // The schema must expose at least the status field (semantically required).
+    let has_status = fields
+        .iter()
+        .any(|f| f["key"] == "status" && f["semantic"] == "status");
+    assert!(has_status, "schema must expose a status field");
+}
+
+#[tokio::test]
+async fn test_get_project_schema_unknown_project() {
+    let registry_dir = TempDir::new().unwrap();
+    let state = create_empty_state(&registry_dir).await;
+    let app = create_router(state);
+
+    let (status, _body) = make_request(app, "GET", "/api/projects/missing/schema").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
## Summary

Implements spec #261 — migrates the `leanspec-http` read path off the markdown-specific `SpecLoader`/`SpecInfo` types and onto the adapter layer (`AdapterRegistry::from_project()` + `SpecDoc`). Spec #258 isolated those markdown internals behind a module boundary and intentionally left the HTTP crate broken as a compiler-guided migration map; this PR restores it.

### Read-path migration (spec scope)

- **`types/specs.rs`** — `SpecSummary` / `SpecDetail` are built from `&SpecDoc` using schema semantic hints (`status`, `priority`, `tags`, `assignee`) rather than `SpecInfo.frontmatter`. The legacy `From<&SpecInfo>` impls are deleted; `From<&SpecDoc>` replaces them. `from_doc` / `from_doc_with_tokens` constructors accept the adapter's schema explicitly.
- **`handlers/specs/helpers.rs`** — `get_loader_and_project` replaced with `get_adapter_and_project` returning `Box<dyn Adapter>`. Shared helpers added for `AdapterError → HTTP` mapping and `require_markdown_adapter` guards.
- **`handlers/specs/read.rs`** — `list` / `get` / `search` / `raw` / sub-spec handlers all go through `adapter.list()` and `adapter.get()`. Hierarchy and `required_by` are computed from `SpecDoc.links` (parent / depends_on) instead of the markdown loader's relationship index. Raw handlers fall through a `require_markdown_adapter` guard since they read the underlying file.
- **`handlers/specs/compute.rs`** — stats group by semantic-hint fields on `SpecDoc`; dependencies and per-spec validation now return HTTP 422 (`{"error":"This operation requires a markdown adapter"}`) when the adapter is not markdown. Per-spec token counting works on `fields["content"]` for non-markdown adapters and reads the file for markdown projects (which need frontmatter included).
- **`watcher.rs` / `state.rs`** — the file watcher now holds `Arc<MarkdownAdapter>` per project for cache invalidation and only activates for projects whose adapter resolves to `markdown`. Non-markdown projects don't register watch targets.
- **`handlers/adapter.rs` + `routes.rs`** — new `GET /api/projects/{id}/schema` returns the active adapter's `SpecSchema` as JSON so the UI can render dynamic field sets.

### Write-path note

Write handlers (`create`, `metadata`, `raw`, `checklist`, `batch`) are migrated minimally to the adapter API so the crate compiles. They continue to use `leanspec_core::adapters::markdown::{SpecInfo, SpecStatus, SpecFrontmatter}` via the *public* markdown module path (not the crate root) for transition checks, umbrella completion verification, and template rendering. The full fetch-transform-push migration is owned by #262.

## Test plan

- [x] `cargo check -p leanspec-http`
- [x] `cargo test -p leanspec-http` — 102 tests passing (existing + new schema endpoint test)
- [x] `cargo clippy -p leanspec-http --tests -- -D warnings`
- [x] `cargo fmt -p leanspec-http -- --check`
- [x] `GET /api/projects/{id}/specs` and `/{id}/specs/{spec}` round-trip for markdown fixtures
- [x] `GET /api/projects/{id}/schema` returns the markdown schema (new `schema_test.rs`)
- [x] Stats endpoint groups by semantic-hint fields for markdown projects (existing `stats_test.rs`)
- [x] No `leanspec_core::SpecLoader|SpecInfo|SpecStatus|SpecPriority|SpecWriter|SpecArchiver` imports remain in `leanspec-http/src/` from the crate root

Closes #261

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPQ3bhKz2eVXmyjABg5HZF)_