### PR TITLE
feat(http): migrate write path to adapter layer (#262)

### DIFF
--- a/rust/leanspec-core/src/adapters/markdown/mod.rs
+++ b/rust/leanspec-core/src/adapters/markdown/mod.rs
@@ -435,6 +435,208 @@ pub fn spec_info_to_doc(info: &SpecInfo) -> SpecDoc {
     }
 }
 
+/// Build a markdown [`SpecInfo`] from a [`SpecDoc`] for code that still needs
+/// the typed markdown view (e.g. running the file-oriented validators).
+///
+/// `body_override` lets callers supply the on-disk body when the doc was loaded
+/// without it; if `None` the body comes from the doc's content field.
+pub fn doc_to_spec_info(doc: &SpecDoc, file_path: PathBuf, body_override: Option<String>) -> SpecInfo {
+    use crate::adapters::markdown::types::SpecFrontmatter;
+    use std::str::FromStr;
+
+    let status = doc
+        .fields
+        .get(field::STATUS)
+        .and_then(|v| v.as_str())
+        .and_then(|s| SpecStatus::from_str(s).ok())
+        .unwrap_or(SpecStatus::Draft);
+
+    let priority = doc
+        .fields
+        .get(field::PRIORITY)
+        .and_then(|v| v.as_str())
+        .and_then(|s| SpecPriority::from_str(s).ok());
+
+    let tags = doc
+        .fields
+        .get(field::TAGS)
+        .and_then(|v| v.as_strings())
+        .map(|s| s.to_vec())
+        .unwrap_or_default();
+
+    let assignee = doc
+        .fields
+        .get(field::ASSIGNEE)
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let reviewer = doc
+        .fields
+        .get(field::REVIEWER)
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let issue = doc
+        .fields
+        .get(field::ISSUE)
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let pr = doc
+        .fields
+        .get(field::PR)
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let epic = doc
+        .fields
+        .get(field::EPIC)
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let breaking = doc.fields.get(field::BREAKING).and_then(|v| v.as_bool());
+    let due = doc
+        .fields
+        .get(field::DUE)
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let created = doc
+        .fields
+        .get(field::CREATED)
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .unwrap_or_default();
+
+    let parent = doc
+        .links
+        .iter()
+        .find(|l| l.link_type == link::PARENT)
+        .map(|l| l.target_id.clone());
+    let depends_on: Vec<String> = doc
+        .links
+        .iter()
+        .filter(|l| l.link_type == link::DEPENDS_ON)
+        .map(|l| l.target_id.clone())
+        .collect();
+
+    let content = body_override.unwrap_or_else(|| {
+        doc.fields
+            .get(field::CONTENT)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    });
+
+    SpecInfo {
+        path: doc.id.clone(),
+        title: doc.title.clone(),
+        frontmatter: SpecFrontmatter {
+            status,
+            created,
+            priority,
+            tags,
+            depends_on,
+            parent,
+            assignee,
+            reviewer,
+            issue,
+            pr,
+            epic,
+            breaking,
+            due,
+            updated: None,
+            completed: None,
+            created_at: doc.created_at,
+            updated_at: doc.updated_at,
+            completed_at: None,
+            transitions: Vec::new(),
+            custom: std::collections::HashMap::new(),
+        },
+        content,
+        file_path,
+        is_sub_spec: false,
+        parent_spec: None,
+    }
+}
+
+/// Verify umbrella completion for a [`SpecDoc`] against a list of sibling docs.
+///
+/// HTTP handlers use this to enforce that all children are complete before
+/// allowing an umbrella spec to transition to `complete`. Operates purely on
+/// the schema-driven doc shape — no SpecInfo/file-system coupling.
+pub fn umbrella_completion_for_docs(
+    spec_id: &str,
+    all_docs: &[SpecDoc],
+) -> crate::types::UmbrellaVerificationResult {
+    use crate::types::{IncompleteChildSpec, Progress, UmbrellaVerificationResult};
+
+    let children: Vec<&SpecDoc> = all_docs
+        .iter()
+        .filter(|d| {
+            d.links
+                .iter()
+                .any(|l| l.link_type == link::PARENT && l.target_id == spec_id)
+        })
+        .collect();
+
+    if children.is_empty() {
+        return UmbrellaVerificationResult::not_umbrella();
+    }
+
+    let incomplete: Vec<IncompleteChildSpec> = children
+        .iter()
+        .filter(|d| {
+            let status = d
+                .fields
+                .get(field::STATUS)
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            status != "complete" && status != "archived"
+        })
+        .map(|d| IncompleteChildSpec {
+            path: d.id.clone(),
+            title: d.title.clone(),
+            status: d
+                .fields
+                .get(field::STATUS)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        })
+        .collect();
+
+    let completed = children.len() - incomplete.len();
+    let total = children.len();
+    let percentage = if total > 0 {
+        (completed as f64 / total as f64) * 100.0
+    } else {
+        100.0
+    };
+
+    let suggestions = if incomplete.is_empty() {
+        Vec::new()
+    } else {
+        let mut s = vec![format!(
+            "Complete {} child spec(s) before marking umbrella as complete",
+            incomplete.len()
+        )];
+        for spec in incomplete.iter().take(3) {
+            s.push(format!("  - {} ({})", spec.path, spec.status));
+        }
+        if incomplete.len() > 3 {
+            s.push(format!("  ... and {} more", incomplete.len() - 3));
+        }
+        s.push("Or use force=true to mark complete anyway".to_string());
+        s
+    };
+
+    UmbrellaVerificationResult {
+        is_complete: incomplete.is_empty(),
+        incomplete_children: incomplete,
+        progress: Progress {
+            completed,
+            total,
+            percentage,
+        },
+        suggestions,
+    }
+}
+
 fn fields_to_frontmatter(
     fields: &HashMap<String, FieldValue>,
     links: &[ItemLink],

--- a/rust/leanspec-http/src/handlers/specs/compute.rs
+++ b/rust/leanspec-http/src/handlers/specs/compute.rs
@@ -9,7 +9,7 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::Json;
 
-use leanspec_core::adapters::markdown::SpecInfo;
+use leanspec_core::adapters::markdown::doc_to_spec_info;
 use leanspec_core::adapters::ListFilter;
 use leanspec_core::{
     global_frontmatter_validator, global_structure_validator, global_token_count_validator,
@@ -54,14 +54,14 @@ fn doc_semantic_strings(doc: &SpecDoc, schema: &SpecSchema, sem: &str) -> Vec<St
     }
 }
 
-/// Reconstruct a `SpecInfo`-shaped value from a `SpecDoc` and on-disk path for
-/// the markdown-only validators that still take `&SpecInfo`. This is a
-/// short-term bridge: when validators move to the schema-driven model the
-/// helper can be removed.
-fn spec_info_for_validation(
+/// Reconstruct a markdown spec view from a [`SpecDoc`] plus the on-disk file
+/// for the validators that still consume `&SpecInfo`. Reads the body off
+/// disk so the validators see the same frontmatter the parser produces — a
+/// short-term bridge until validators move to the schema-driven model.
+fn doc_to_spec_info_from_disk(
     doc: &SpecDoc,
     file_path: std::path::PathBuf,
-) -> Result<SpecInfo, (StatusCode, Json<ApiError>)> {
+) -> Result<leanspec_core::adapters::markdown::SpecInfo, (StatusCode, Json<ApiError>)> {
     let content = fs::read_to_string(&file_path).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -70,28 +70,14 @@ fn spec_info_for_validation(
     })?;
 
     let parser = FrontmatterParser::new();
-    let (frontmatter, body) = parser.parse(&content).map_err(|e| {
+    let (_, body) = parser.parse(&content).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiError::internal_error(&e.to_string())),
         )
     })?;
 
-    let title = body
-        .lines()
-        .find(|l| l.starts_with("# "))
-        .map(|l| l.trim_start_matches("# ").to_string())
-        .unwrap_or_else(|| doc.title.clone());
-
-    Ok(SpecInfo {
-        path: doc.id.clone(),
-        title,
-        frontmatter,
-        content: body,
-        file_path,
-        is_sub_spec: false,
-        parent_spec: None,
-    })
+    Ok(doc_to_spec_info(doc, file_path, Some(body)))
 }
 
 /// GET /api/projects/:projectId/specs/:spec/tokens - Get token counts for a spec
@@ -170,7 +156,7 @@ pub async fn get_project_spec_validation(
         )
     })?;
 
-    let spec_info = spec_info_for_validation(&doc, file_path)?;
+    let spec_info = doc_to_spec_info_from_disk(&doc, file_path)?;
 
     let fm_validator = global_frontmatter_validator();
     let struct_validator = global_structure_validator();

--- a/rust/leanspec-http/src/handlers/specs/write.rs
+++ b/rust/leanspec-http/src/handlers/specs/write.rs
@@ -1,11 +1,12 @@
 //! Spec write handlers: create, update, toggle, batch metadata
 //!
 //! The HTTP read path is adapter-driven (see [`super::read`] and spec #261).
-//! Write handlers in this module use the adapter API for create/update/delete
-//! and the markdown adapter's typed helpers (`SpecInfo`,
-//! `CompletionVerifier`) for markdown-specific behaviour like umbrella
-//! completion checks and template rendering. Full migration to a
-//! schema-driven write path lives in spec #262.
+//! Write handlers run on the same fetch-transform-push pattern: load a
+//! [`SpecDoc`] from the adapter, apply schema-aware updates or pure string
+//! transforms to its fields, then push the result back through
+//! [`Adapter::update`]. Markdown-specific operations (raw spec / sub-spec
+//! writes) are kept as direct file I/O behind `require_markdown_adapter` —
+//! those concepts don't generalise to other adapters.
 
 #![allow(clippy::result_large_err)]
 
@@ -18,14 +19,16 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::Json;
 
-use leanspec_core::adapters::markdown::{SpecInfo, SpecStatus};
+use leanspec_core::adapters::markdown::{
+    doc_to_spec_info, umbrella_completion_for_docs, MarkdownAdapter,
+};
 use leanspec_core::adapters::ListFilter;
 use leanspec_core::io::hash_content;
 use leanspec_core::{
     apply_checklist_toggles, global_frontmatter_validator, global_structure_validator,
     global_token_count_validator, global_token_counter, rebuild_content, semantic,
-    split_frontmatter, ChecklistToggle, CompletionVerifier, FieldValue, FrontmatterParser, SpecDoc,
-    SpecSchema, TemplateLoader, TokenStatus, UpdateRequest, ValidationResult,
+    split_frontmatter, ChecklistToggle, ErrorSeverity, FieldKind, FieldValue, FrontmatterParser,
+    SpecDoc, SpecSchema, TemplateLoader, TokenStatus, UpdateRequest, ValidationResult,
 };
 
 use crate::error::{ApiError, ApiResult};
@@ -91,8 +94,6 @@ fn validate_enum_value(
     field_key: &str,
     value: &str,
 ) -> Result<(), (StatusCode, Json<ApiError>)> {
-    use leanspec_core::FieldKind;
-
     let Some(field) = schema.field(field_key) else {
         return Ok(());
     };
@@ -304,6 +305,14 @@ pub async fn update_project_spec_raw(
 }
 
 /// POST /api/projects/:projectId/specs/:spec/checklist-toggle - Toggle checklist items
+///
+/// Main-spec toggles run the fetch-transform-push pattern through the adapter:
+/// pull the body via `adapter.get`, apply the pure `apply_checklist_toggles`
+/// transform, push back via `adapter.update` with the `content` field. Hashes
+/// are body-only, matching the list/detail endpoints.
+///
+/// Sub-spec toggles stay as direct file I/O — sub-specs are a markdown-only
+/// concept that doesn't surface through the adapter API.
 pub async fn toggle_project_spec_checklist(
     State(state): State<AppState>,
     Path((project_id, spec_id)): Path<(String, String)>,
@@ -311,60 +320,6 @@ pub async fn toggle_project_spec_checklist(
 ) -> ApiResult<Json<ChecklistToggleResponse>> {
     let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
     require_markdown_adapter(adapter.as_ref())?;
-
-    adapter.get(&spec_id).map_err(adapter_error)?;
-
-    let spec_readme =
-        resolve_markdown_spec_path(&project.specs_dir, &spec_id).ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ApiError::spec_not_found(&spec_id)),
-            )
-        })?;
-
-    let file_path = if let Some(ref subspec_file) = request.subspec {
-        if subspec_file.contains('/') || subspec_file.contains('\\') {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(ApiError::invalid_request("Invalid sub-spec file")),
-            ));
-        }
-        let parent_dir = spec_readme.parent().ok_or_else(|| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ApiError::internal_error("Missing spec directory")),
-            )
-        })?;
-        let sub_path = parent_dir.join(subspec_file);
-        if !sub_path.exists() {
-            return Err((
-                StatusCode::NOT_FOUND,
-                Json(ApiError::invalid_request("Sub-spec not found")),
-            ));
-        }
-        sub_path
-    } else {
-        spec_readme
-    };
-
-    let content = fs::read_to_string(&file_path).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )
-    })?;
-    let current_hash = hash_raw_content(&content);
-
-    if let Some(expected) = &request.expected_content_hash {
-        if expected != &current_hash {
-            return Err((
-                StatusCode::CONFLICT,
-                Json(ApiError::invalid_request("Content hash mismatch").with_details(current_hash)),
-            ));
-        }
-    }
-
-    let (frontmatter, body) = split_frontmatter(&content);
 
     let toggles: Vec<ChecklistToggle> = request
         .toggles
@@ -375,9 +330,120 @@ pub async fn toggle_project_spec_checklist(
         })
         .collect();
 
+    if let Some(subspec_file) = request.subspec.as_deref() {
+        return toggle_subspec_checklist(
+            adapter.as_ref(),
+            &project.specs_dir,
+            &spec_id,
+            subspec_file,
+            request.expected_content_hash.as_deref(),
+            &toggles,
+        );
+    }
+
+    // Main-spec path: fetch-transform-push through the adapter.
+    let doc = adapter.get(&spec_id).map_err(adapter_error)?;
+    let body = doc
+        .fields
+        .get("content")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let current_hash = hash_content(&body);
+
+    if let Some(expected) = &request.expected_content_hash {
+        if expected != &current_hash {
+            return Err((
+                StatusCode::CONFLICT,
+                Json(ApiError::invalid_request("Content hash mismatch").with_details(current_hash)),
+            ));
+        }
+    }
+
     let (updated_body, results) = apply_checklist_toggles(&body, &toggles)
         .map_err(|e| (StatusCode::BAD_REQUEST, Json(ApiError::invalid_request(&e))))?;
 
+    let mut req_fields: HashMap<String, FieldValue> = HashMap::new();
+    req_fields.insert("content".into(), FieldValue::String(updated_body.clone()));
+    let update = UpdateRequest {
+        fields: req_fields,
+        ..Default::default()
+    };
+    adapter.update(&spec_id, &update).map_err(adapter_error)?;
+
+    let new_hash = hash_content(&updated_body);
+
+    Ok(Json(ChecklistToggleResponse {
+        success: true,
+        content_hash: new_hash,
+        toggled: results
+            .into_iter()
+            .map(|r| ChecklistToggledResult {
+                item_text: r.item_text,
+                checked: r.checked,
+                line: r.line,
+            })
+            .collect(),
+    }))
+}
+
+/// Sub-spec checklist toggle — markdown-only direct file I/O.
+fn toggle_subspec_checklist(
+    adapter: &dyn leanspec_core::adapters::Adapter,
+    specs_dir: &FsPath,
+    spec_id: &str,
+    subspec_file: &str,
+    expected_hash: Option<&str>,
+    toggles: &[ChecklistToggle],
+) -> ApiResult<Json<ChecklistToggleResponse>> {
+    if subspec_file.contains('/') || subspec_file.contains('\\') {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ApiError::invalid_request("Invalid sub-spec file")),
+        ));
+    }
+    // Adapter.get confirms the parent spec exists.
+    adapter.get(spec_id).map_err(adapter_error)?;
+
+    let spec_readme = resolve_markdown_spec_path(specs_dir, spec_id).ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ApiError::spec_not_found(spec_id)),
+        )
+    })?;
+    let parent_dir = spec_readme.parent().ok_or_else(|| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiError::internal_error("Missing spec directory")),
+        )
+    })?;
+    let file_path = parent_dir.join(subspec_file);
+    if !file_path.exists() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ApiError::invalid_request("Sub-spec not found")),
+        ));
+    }
+
+    let content = fs::read_to_string(&file_path).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiError::internal_error(&e.to_string())),
+        )
+    })?;
+    let current_hash = hash_raw_content(&content);
+    if let Some(expected) = expected_hash {
+        if expected != current_hash {
+            return Err((
+                StatusCode::CONFLICT,
+                Json(ApiError::invalid_request("Content hash mismatch").with_details(current_hash)),
+            ));
+        }
+    }
+
+    let (frontmatter, body) = split_frontmatter(&content);
+    let (updated_body, results) = apply_checklist_toggles(&body, toggles)
+        .map_err(|e| (StatusCode::BAD_REQUEST, Json(ApiError::invalid_request(&e))))?;
     let updated_content = rebuild_content(frontmatter, &updated_body);
 
     fs::write(&file_path, &updated_content).map_err(|e| {
@@ -386,9 +452,7 @@ pub async fn toggle_project_spec_checklist(
             Json(ApiError::internal_error(&e.to_string())),
         )
     })?;
-
-    invalidate_markdown_cache(&project.specs_dir, &file_path);
-
+    invalidate_markdown_cache(specs_dir, &file_path);
     let new_hash = hash_raw_content(&updated_content);
 
     Ok(Json(ChecklistToggleResponse {
@@ -530,18 +594,13 @@ pub async fn update_project_metadata(
                 }
 
                 if status_str == "complete" && !updates.force.unwrap_or(false) {
-                    // Umbrella completion check still uses markdown's
-                    // SpecInfo-typed verifier. The check loads every spec
-                    // through the adapter and projects them to SpecInfo.
                     let all_docs = adapter
                         .list(&ListFilter {
                             include_archived: true,
                             ..Default::default()
                         })
                         .map_err(adapter_error)?;
-                    let all_specs = docs_to_spec_info(&all_docs, schema);
-                    let umbrella =
-                        CompletionVerifier::verify_umbrella_completion(&spec_id, &all_specs);
+                    let umbrella = umbrella_completion_for_docs(&spec_id, &all_docs);
                     if !umbrella.is_complete {
                         let names: Vec<_> = umbrella
                             .incomplete_children
@@ -719,31 +778,29 @@ pub async fn batch_spec_metadata(
         };
 
         let validation_status_str = if adapter.capabilities().name == "markdown" {
-            // Reconstruct SpecInfo from the on-disk file for the markdown
-            // validators. Non-markdown adapters get "pass" by default until
-            // schema-driven validation lands in spec #262.
+            // Markdown validators consume `SpecInfo` and look at the on-disk
+            // path. Non-markdown adapters get "pass" by default until
+            // schema-driven validation lands.
             match resolve_markdown_spec_path(&project.specs_dir, spec_name) {
-                Some(file_path) => match build_spec_info(doc, file_path) {
-                    Some(info) => {
-                        let mut validation_result = ValidationResult::new(&info.path);
-                        validation_result.merge(fm_validator.validate(&info));
-                        validation_result.merge(struct_validator.validate(&info));
-                        validation_result.merge(token_validator.validate(&info));
+                Some(file_path) => {
+                    let info = doc_to_spec_info(doc, file_path, None);
+                    let mut validation_result = ValidationResult::new(&info.path);
+                    validation_result.merge(fm_validator.validate(&info));
+                    validation_result.merge(struct_validator.validate(&info));
+                    validation_result.merge(token_validator.validate(&info));
 
-                        if validation_result.errors.is_empty() {
-                            "pass"
-                        } else if validation_result
-                            .errors
-                            .iter()
-                            .any(|e| e.severity == leanspec_core::ErrorSeverity::Error)
-                        {
-                            "fail"
-                        } else {
-                            "warn"
-                        }
+                    if validation_result.errors.is_empty() {
+                        "pass"
+                    } else if validation_result
+                        .errors
+                        .iter()
+                        .any(|e| e.severity == ErrorSeverity::Error)
+                    {
+                        "fail"
+                    } else {
+                        "warn"
                     }
-                    None => "pass",
-                },
+                }
                 None => "pass",
             }
         } else {
@@ -769,85 +826,5 @@ pub async fn batch_spec_metadata(
 /// Invalidate the markdown adapter's static spec cache for a path. Safe to
 /// call from non-markdown contexts (a no-op when the path is unknown).
 fn invalidate_markdown_cache(specs_dir: &FsPath, path: &FsPath) {
-    leanspec_core::adapters::markdown::MarkdownAdapter::new(specs_dir).invalidate_path(path);
-}
-
-fn build_spec_info(doc: &SpecDoc, file_path: std::path::PathBuf) -> Option<SpecInfo> {
-    let content = fs::read_to_string(&file_path).ok()?;
-    let parser = FrontmatterParser::new();
-    let (frontmatter, body) = parser.parse(&content).ok()?;
-    let title = body
-        .lines()
-        .find(|l| l.starts_with("# "))
-        .map(|l| l.trim_start_matches("# ").to_string())
-        .unwrap_or_else(|| doc.title.clone());
-    Some(SpecInfo {
-        path: doc.id.clone(),
-        title,
-        frontmatter,
-        content: body,
-        file_path,
-        is_sub_spec: false,
-        parent_spec: None,
-    })
-}
-
-/// Project the adapter's documents to markdown `SpecInfo` for the umbrella
-/// verifier. Only meaningful for markdown projects.
-fn docs_to_spec_info(docs: &[SpecDoc], schema: &SpecSchema) -> Vec<SpecInfo> {
-    use leanspec_core::adapters::markdown::SpecFrontmatter;
-    docs.iter()
-        .map(|doc| {
-            let status_str = doc
-                .fields
-                .get(
-                    schema
-                        .key_for_semantic(semantic::STATUS)
-                        .unwrap_or("status"),
-                )
-                .and_then(|v| v.as_str())
-                .unwrap_or("draft");
-            let status = status_str
-                .parse::<SpecStatus>()
-                .unwrap_or(SpecStatus::Draft);
-            let parent = doc
-                .links
-                .iter()
-                .find(|l| l.link_type == "parent")
-                .map(|l| l.target_id.clone());
-
-            let frontmatter = SpecFrontmatter {
-                status,
-                created: String::new(),
-                priority: None,
-                tags: Vec::new(),
-                depends_on: Vec::new(),
-                parent,
-                assignee: None,
-                reviewer: None,
-                issue: None,
-                pr: None,
-                epic: None,
-                breaking: None,
-                due: None,
-                updated: None,
-                completed: None,
-                created_at: None,
-                updated_at: None,
-                completed_at: None,
-                transitions: Vec::new(),
-                custom: std::collections::HashMap::new(),
-            };
-
-            SpecInfo {
-                path: doc.id.clone(),
-                title: doc.title.clone(),
-                frontmatter,
-                content: String::new(),
-                file_path: std::path::PathBuf::new(),
-                is_sub_spec: false,
-                parent_spec: None,
-            }
-        })
-        .collect()
+    MarkdownAdapter::new(specs_dir).invalidate_path(path);
 }

--- a/rust/leanspec-http/src/handlers/specs/write.rs
+++ b/rust/leanspec-http/src/handlers/specs/write.rs
@@ -306,20 +306,21 @@ pub async fn update_project_spec_raw(
 
 /// POST /api/projects/:projectId/specs/:spec/checklist-toggle - Toggle checklist items
 ///
-/// Main-spec toggles run the fetch-transform-push pattern through the adapter:
-/// pull the body via `adapter.get`, apply the pure `apply_checklist_toggles`
-/// transform, push back via `adapter.update` with the `content` field. Hashes
-/// are body-only, matching the list/detail endpoints.
+/// Main-spec toggles run the fetch-transform-push pattern through the adapter
+/// and work for any backend that exposes a `content` field: pull the body via
+/// `adapter.get`, apply the pure `apply_checklist_toggles` transform, push back
+/// via `adapter.update`. Body-only content hashes match the list/detail
+/// endpoints.
 ///
-/// Sub-spec toggles stay as direct file I/O — sub-specs are a markdown-only
-/// concept that doesn't surface through the adapter API.
+/// Sub-spec toggles fall back to direct file I/O and require the markdown
+/// adapter — sub-specs are extra files inside the spec directory and aren't
+/// modelled by the adapter API.
 pub async fn toggle_project_spec_checklist(
     State(state): State<AppState>,
     Path((project_id, spec_id)): Path<(String, String)>,
     Json(request): Json<ChecklistToggleRequest>,
 ) -> ApiResult<Json<ChecklistToggleResponse>> {
     let (adapter, project) = get_adapter_and_project(&state, &project_id).await?;
-    require_markdown_adapter(adapter.as_ref())?;
 
     let toggles: Vec<ChecklistToggle> = request
         .toggles
@@ -331,6 +332,9 @@ pub async fn toggle_project_spec_checklist(
         .collect();
 
     if let Some(subspec_file) = request.subspec.as_deref() {
+        // Sub-specs are markdown-only — they live as extra files inside
+        // the spec directory and aren't represented in the adapter model.
+        require_markdown_adapter(adapter.as_ref())?;
         return toggle_subspec_checklist(
             adapter.as_ref(),
             &project.specs_dir,

--- a/rust/leanspec-http/tests/specs_test.rs
+++ b/rust/leanspec-http/tests/specs_test.rs
@@ -288,3 +288,132 @@ async fn test_invalid_query_parameters() {
     // Should still succeed but filter nothing (or handle gracefully)
     assert!(status == StatusCode::OK || status == StatusCode::BAD_REQUEST);
 }
+
+#[tokio::test]
+async fn test_update_metadata_invalid_status_returns_422() {
+    // Schema-driven validation: status values outside the markdown enum
+    // (draft/planned/in-progress/complete/archived) should be rejected with
+    // HTTP 422 and surface the list of valid values in the response.
+    let temp_dir = TempDir::new().unwrap();
+    let state = create_test_state(&temp_dir).await;
+    let app = create_router(state.clone());
+
+    let project_id = {
+        let reg = state.registry.read().await;
+        let projects = reg.all();
+        projects.first().unwrap().id.clone()
+    };
+
+    let (status, body) = make_json_request(
+        app,
+        "PATCH",
+        &format!("/api/projects/{}/specs/001-first-spec/metadata", project_id),
+        &serde_json::json!({ "status": "totally-not-a-status" }).to_string(),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    let parsed: Value = serde_json::from_str(&body).unwrap();
+    let valid = parsed
+        .pointer("/details/validValues")
+        .and_then(|v| v.as_array())
+        .expect("response should advertise valid enum values");
+    let labels: Vec<&str> = valid.iter().filter_map(|v| v.as_str()).collect();
+    for expected in &["draft", "planned", "in-progress", "complete", "archived"] {
+        assert!(
+            labels.contains(expected),
+            "expected '{}' among valid values, got {:?}",
+            expected,
+            labels
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_checklist_toggle_round_trips_through_adapter() {
+    // The toggle handler should fetch the current body via the adapter,
+    // apply the requested toggle as a pure string transform, and push the
+    // new body back through `adapter.update`. A second `GET` should then
+    // observe the toggled state.
+    let temp_dir = TempDir::new().unwrap();
+    let state = create_test_state(&temp_dir).await;
+    let app = create_router(state.clone());
+
+    let project_id = {
+        let reg = state.registry.read().await;
+        let projects = reg.all();
+        projects.first().unwrap().id.clone()
+    };
+
+    let (status, _body) = make_json_request(
+        app.clone(),
+        "POST",
+        &format!(
+            "/api/projects/{}/specs/001-first-spec/checklist-toggle",
+            project_id
+        ),
+        &serde_json::json!({
+            "toggles": [{"itemText": "Step 1", "checked": true}]
+        })
+        .to_string(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, body) = make_request(
+        app,
+        "GET",
+        &format!("/api/projects/{}/specs/001-first-spec/raw", project_id),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body.contains("- [x] Step 1"),
+        "Step 1 should be toggled to checked; got: {}",
+        body
+    );
+    assert!(
+        body.contains("- [ ] Step 2"),
+        "Step 2 should remain unchecked; got: {}",
+        body
+    );
+}
+
+#[tokio::test]
+async fn test_umbrella_completion_blocks_when_children_incomplete() {
+    use std::fs;
+    let temp_dir = TempDir::new().unwrap();
+    let state = create_test_state(&temp_dir).await;
+
+    // Make 002-second-spec a child of 001-first-spec so 001 becomes an
+    // umbrella with an incomplete child (002 is in-progress).
+    let spec2_readme = temp_dir.path().join("specs/002-second-spec/README.md");
+    let original = fs::read_to_string(&spec2_readme).unwrap();
+    let with_parent = original.replacen(
+        "depends_on:\n  - 001-first-spec",
+        "depends_on:\n  - 001-first-spec\nparent: 001-first-spec",
+        1,
+    );
+    fs::write(&spec2_readme, with_parent).unwrap();
+
+    let app = create_router(state.clone());
+    let project_id = {
+        let reg = state.registry.read().await;
+        let projects = reg.all();
+        projects.first().unwrap().id.clone()
+    };
+
+    let (status, body) = make_json_request(
+        app,
+        "PATCH",
+        &format!("/api/projects/{}/specs/001-first-spec/metadata", project_id),
+        &serde_json::json!({ "status": "complete" }).to_string(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body.contains("child spec"),
+        "error should mention incomplete child specs; got: {}",
+        body
+    );
+}


### PR DESCRIPTION
## Summary

Migrates `leanspec-http` write handlers to the adapter layer, completing the fetch-transform-push pattern started in the read-path migration (#261). HTTP no longer imports markdown-internal types (`SpecInfo`, `SpecStatus`, `SpecWriter`, `SpecArchiver`).

Closes #262.

### Changes

**`leanspec-core/src/adapters/markdown/mod.rs`** — new public bridges so HTTP can stay schema-driven without dragging in markdown internals:

- `doc_to_spec_info(doc, file_path, body_override)` — projects a `SpecDoc` back to `SpecInfo` for code that still calls into the file-oriented validators. The optional `body_override` lets callers supply the on-disk body when needed (the validators look at parsed body content).
- `umbrella_completion_for_docs(spec_id, all_docs)` — schema-driven umbrella completion check. Walks `SpecDoc.links` / fields directly; replaces the `CompletionVerifier::verify_umbrella_completion` path that took `&[SpecInfo]`.

**`leanspec-http/src/handlers/specs/write.rs`**:

- `toggle_project_spec_checklist` — main-spec path is now fetch-transform-push:
  ```
  adapter.get(id) → SpecDoc
  → doc.fields["content"] as &str
  → apply_checklist_toggles(content, &toggles)  (pure fn)
  → adapter.update(id, UpdateRequest { fields: { "content": …new body… } })
  ```
  Body-only content hashes, matching the read endpoints. Sub-spec toggles stay as markdown-only direct file I/O behind `require_markdown_adapter` — sub-specs aren't a concept that crosses to other adapters.
- `update_project_metadata` — umbrella check uses the new schema-driven helper, no more `docs_to_spec_info` projection inside the handler.
- `batch_spec_metadata` — uses `markdown::doc_to_spec_info` instead of the inline `build_spec_info`.
- Drops local `build_spec_info` / `docs_to_spec_info` helpers.

**`leanspec-http/src/handlers/specs/compute.rs`** — same `doc_to_spec_info` bridge for the validation endpoint. The handler still reads the file once to parse the on-disk body (so validators see the same frontmatter `FrontmatterParser` produces), but no longer constructs `SpecInfo` inline or carries the import.

### Imports check

```
$ grep -rn "use leanspec_core.*\(SpecInfo\|SpecStatus\|SpecWriter\|SpecArchiver\)" leanspec-http/src/
(no matches)
```

The validation helper in `compute.rs` retains one fully-qualified `SpecInfo` in its return type — a short-term bridge until the validators move to the schema-driven model.

## Test plan

- [x] `cargo test -p leanspec-http` — 119 tests pass (62 lib + 57 across integration suites)
- [x] `cargo test -p leanspec-core` — 234 tests pass
- [x] `cargo clippy -p leanspec-http -p leanspec-core --all-targets -- -D warnings` — clean
- [x] New integration tests in `tests/specs_test.rs`:
  - `test_update_metadata_invalid_status_returns_422` — schema-driven enum validation surfaces `validValues` list in the response
  - `test_checklist_toggle_round_trips_through_adapter` — toggle a checkbox, re-fetch raw, verify the new state lands on disk
  - `test_umbrella_completion_blocks_when_children_incomplete` — parent → in-progress-child umbrella complete is rejected with the helper child list in the error
- [x] Existing `test_update_spec_metadata_not_implemented` (status update happy path) continues to pass

### Out of scope

The plan also lists "migrate `create_project_spec` to `adapter.create()`" and "migrate raw spec updates". Both are kept as markdown-only direct file I/O for now because the HTTP API contracts differ from `adapter.create()` (the API takes a verbatim numbered name; the adapter auto-numbers) and the raw endpoint inherently writes full-file markdown including frontmatter. Both endpoints are gated by `require_markdown_adapter`. Moving transition logic inside `MarkdownAdapter::update()` also stays open — it requires plumbing the `force` flag through `UpdateRequest`, which is a bigger surface-area change worth its own PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T1rQYY5j1rT2Cum7E72W4X)_